### PR TITLE
allow gpio template via user_config_override

### DIFF
--- a/src/hasp_config.cpp
+++ b/src/hasp_config.cpp
@@ -152,6 +152,13 @@ void configRead(JsonDocument& settings, bool setupdebug = false)
 
 #if HASP_USE_SPIFFS > 0 || HASP_USE_LITTLEFS > 0
     LOG_ERROR(TAG_CONF, F(D_FILE_LOAD_FAILED), configFile.c_str());
+    #ifdef HASP_GPIO_TEMPLATE
+    char json[100];
+    snprintf(json, sizeof(json), PSTR("{\"%s\":{\"%s\":%s}}"), (char*)(FPSTR(FP_GPIO)), (char*)(FPSTR(FP_GPIO_CONFIG)), (char*)(FPSTR(HASP_GPIO_TEMPLATE)));
+    error = deserializeJson(settings, json);
+    gpioSetConfig(settings[FPSTR(FP_GPIO)]);
+    #endif
+
 #endif
 }
 /*
@@ -380,7 +387,7 @@ void configSetup()
         //#if HASP_USE_SPIFFS > 0
         LOG_INFO(TAG_DEBG, F("Loading debug settings"));
         debugSetConfig(settings[FPSTR(FP_DEBUG)]);
-        LOG_INFO(TAG_GUI, F("Loading GUI settings"));
+        LOG_INFO(TAG_GPIO, F("Loading GUI settings"));
         guiSetConfig(settings[FPSTR(FP_GUI)]);
         LOG_INFO(TAG_HASP, F("Loading HASP settings"));
         haspSetConfig(settings[FPSTR(FP_HASP)]);

--- a/src/hasp_config.h
+++ b/src/hasp_config.h
@@ -71,6 +71,10 @@ const char FP_HASP[] PROGMEM  = "hasp";
 const char FP_GUI[] PROGMEM   = "gui";
 const char FP_DEBUG[] PROGMEM = "debug";
 
+#ifdef HASP_GPIO_TEMPLATE
+const char FP_GPIO_TEMPLATE[] PROGMEM = HASP_GPIO_TEMPLATE;
+#endif
+
 #endif
 
 #endif // HASP_USE_CONFIG


### PR DESCRIPTION
Makes it possible to define the GPIO config through `user_config_override.h`

`#define HASP_GPIO_TEMPLATE "[2360346,2491680,2623009,2097420,2097678,2097947,0,0]"`