### PR TITLE
gpio template via user_config_override

### DIFF
--- a/src/hasp/hasp_dispatch.cpp
+++ b/src/hasp/hasp_dispatch.cpp
@@ -53,7 +53,7 @@ struct moodlight_t
 };
 moodlight_t moodlight;
 
-static void dispatch_config(const char* topic, const char* payload);
+// static void dispatch_config(const char* topic, const char* payload);
 // void dispatch_group_value(uint8_t groupid, int16_t state, lv_obj_t * obj);
 
 /* Sends the payload out on the state/subtopic
@@ -420,7 +420,7 @@ void dispatch_output_idle_state(uint8_t state)
 
 #if HASP_USE_CONFIG > 0
 // Get or Set a part of the config.json file
-static void dispatch_config(const char* topic, const char* payload)
+void dispatch_config(const char* topic, const char* payload)
 {
     DynamicJsonDocument doc(128 * 2);
     char buffer[128 * 2];

--- a/src/hasp/hasp_dispatch.h
+++ b/src/hasp/hasp_dispatch.h
@@ -72,6 +72,8 @@ void dispatch_normalized_group_value(uint8_t groupid, lv_obj_t* obj, int16_t val
 
 void dispatch_state_subtopic(const char* subtopic, const char* payload);
 
+void dispatch_config(const char* topic, const char* payload);
+
 /* ===== Getter and Setter Functions ===== */
 
 /* ===== Read/Write Configuration ===== */

--- a/src/hasp_config.cpp
+++ b/src/hasp_config.cpp
@@ -152,13 +152,11 @@ void configRead(JsonDocument& settings, bool setupdebug = false)
 
 #if HASP_USE_SPIFFS > 0 || HASP_USE_LITTLEFS > 0
     LOG_ERROR(TAG_CONF, F(D_FILE_LOAD_FAILED), configFile.c_str());
-    #ifdef HASP_GPIO_TEMPLATE
-    char json[100];
-    snprintf(json, sizeof(json), PSTR("{\"%s\":{\"%s\":%s}}"), (char*)(FPSTR(FP_GPIO)), (char*)(FPSTR(FP_GPIO_CONFIG)), (char*)(FPSTR(HASP_GPIO_TEMPLATE)));
-    error = deserializeJson(settings, json);
-    gpioSetConfig(settings[FPSTR(FP_GPIO)]);
-    #endif
-
+#endif
+#if HASP_USE_CONFIG > 0 && defined(HASP_GPIO_TEMPLATE)
+    char json[96]; 
+    snprintf(json, sizeof(json), PSTR("{\"%s\":%s}"), (char*)(FPSTR(FP_GPIO_CONFIG)), (char*)(FPSTR(FP_GPIO_TEMPLATE)));
+    dispatch_config((char*)(FPSTR(FP_GPIO)), json);
 #endif
 }
 /*


### PR DESCRIPTION
update to re-use existing functions.

define `HASP_GPIO_TEMPLATE` in `user_config_override.h`

`#define HASP_GPIO_TEMPLATE "[2097433,2097691,2097952,131361,131619,0,0,0]"`