### PR TITLE
[WIP/Feedback wanted] - Initial attempt to get display res/orientation info into the HA discovery payload

### DIFF
--- a/src/hasp/hasp_dispatch.cpp
+++ b/src/hasp/hasp_dispatch.cpp
@@ -1109,6 +1109,17 @@ void dispatch_send_discovery(const char*, const char*, uint8_t source)
     JsonArray led    = doc.createNestedArray(F("light"));
     JsonArray dimmer = doc.createNestedArray(F("dim"));
 
+    // Display information; orientation and resolution
+    JsonObject display_info = doc.createNestedObject(F("disp"));
+    uint16_t disp_info[3];
+    guiGetDisplayRes(disp_info);
+    LOG_VERBOSE(TAG_MQTT_PUB, F("guiGetDisplayInfo. disp_info: %u, %u, %u"), disp_info[0], disp_info[1], disp_info[2]);
+
+    // We could also drop the orientation and just send the x/y and let the client infer orientation from x/y?
+    display_info[F("xres")] = disp_info[0];
+    display_info[F("yres")] = disp_info[1];
+    display_info[F("ori")]  = disp_info[2];
+
 #if HASP_USE_GPIO > 0
     gpio_discovery(input, relay, led, dimmer);
 #endif

--- a/src/hasp_gui.cpp
+++ b/src/hasp_gui.cpp
@@ -770,3 +770,14 @@ void guiTakeScreenshot()
     }
 }
 #endif
+
+/** (basic) display info
+ *
+ **/
+void guiGetDisplayRes(uint16_t pInfoArr[3])
+{
+    // X,Y dimensions assuming default orientation
+    pInfoArr[0] = tft_width;
+    pInfoArr[1] = tft_height;
+    pInfoArr[2] = gui_settings.rotation;
+}

--- a/src/hasp_gui.h
+++ b/src/hasp_gui.h
@@ -28,6 +28,7 @@ void gui_hide_pointer(bool hidden);
 void guiCalibrate(void);
 void guiTakeScreenshot(const char* pFileName); // to file
 void guiTakeScreenshot(void);                  // webclient
+void guiGetDisplayRes(uint16_t pInfoArr[3]);   // HA Discovery
 
 /* ===== Read/Write Configuration ===== */
 #if HASP_USE_CONFIG > 0


### PR DESCRIPTION
An attempt to address https://github.com/HASwitchPlate/openHASP/issues/278

I do not spend a lot of time in c/c++ land. I could not figure out how to pass a pointer to an integer array and then store the values so I just pass in the integer array.

I also don't know if this should be turned into 3 functions and the functions should be added to the `haspDevice` obj.

e.g.:

```
jsonDoc[xres] = haspDevice.get_disp_x_res();
jsonDoc[yres] = haspDevice.get_disp_y_res();
jsonDoc[orient] = haspDevice.get_disp_orientation()
```

Or if i should just put the keyboard down and let the pros do it... ?

