### PR TITLE
Tasmota core 2.0.2.3

### DIFF
--- a/user_setups/esp32/_esp32.ini
+++ b/user_setups/esp32/_esp32.ini
@@ -126,7 +126,7 @@ board_build.partitions = user_setups/esp32/partitions_16MB.csv
 ; -- The Arduino ESP32 v2.0.2 with 3 available flash sizes:
 [arduino_esp32_v2]
 framework = arduino
-platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.2/platform-tasmota-espressif32-2.0.2.zip
+platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3.zip
 board_build.embed_files =
     data/edit.htm.gz
     data/style.css.gz


### PR DESCRIPTION
based on idf44 and arduino commits from 24 Feb.
Probably very close to the upcoming core 2.0.3

Greetings from Tasmota team :-)

Solo1 build is updated too. 
https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3solo1.zip