### PR TITLE
Make MQTT work with Ethernet

### DIFF
--- a/src/sys/net/hasp_ethernet_esp32.cpp
+++ b/src/sys/net/hasp_ethernet_esp32.cpp
@@ -40,12 +40,12 @@ void EthernetEvent(WiFiEvent_t event)
             }
             LOG_TRACE(TAG_ETH, F(D_INFO_LINK_SPEED " %d Mbps"), HASP_ETHERNET.linkSpeed());
             eth_connected = true;
-            networkStart(); // Start network services
+            network_connected(); // Start network services
             break;
         case ARDUINO_EVENT_ETH_DISCONNECTED:
             LOG_TRACE(TAG_ETH, F(D_SERVICE_DISCONNECTED));
             eth_connected = false;
-            networkStop(); // Stop network services
+            network_disconnected(); // Stop network services
             break;
         case ARDUINO_EVENT_ETH_STOP:
             LOG_WARNING(TAG_ETH, F(D_SERVICE_STOPPED));


### PR DESCRIPTION
Called the new functions network_connected() and network_disconnected() instead of directly calling networkStart() and networkStop(). 

This accounts for the change to networkEvery5Seconds() which no longer directly checks for the ethernet connection status. 

So now MQTT will connect as it should