### PR TITLE
Add option to auto create other standard files

### DIFF
--- a/src/hasp_filesystem.cpp
+++ b/src/hasp_filesystem.cpp
@@ -215,6 +215,15 @@ void filesystemSetupFiles()
     filesystem_write_file("/pages.jsonl", HASP_PAGES_JSONL);
     filesystem_write_file("/online.cmd", HASP_ONLINE_CMD);
     filesystem_write_file("/offline.cmd", HASP_OFFLINE_CMD);
+#ifdef HASP_BOOT_CMD
+    filesystem_write_file("/boot.cmd", HASP_BOOT_CMD);
+#endif
+#ifdef HASP_MQTT_ON_CMD
+    filesystem_write_file("/mqtt_on.cmd", HASP_MQTT_ON_CMD);
+#endif
+#ifdef HASP_MQTT_OFF_CMD
+    filesystem_write_file("/mqtt_off.cmd", HASP_MQTT_OFF_CMD);
+#endif
 }
 
 bool filesystemSetup(void)


### PR DESCRIPTION
Added the following defines to allow auto creation of missing files during file system creation (after a factory reset)

HASP_BOOT_CMD
HASP_MQTT_ON_CMD
HASP_MQTT_OFF_CMD