### PR TITLE
Improve cpicker in two ways

### DIFF
--- a/src/hasp/hasp_attribute.h
+++ b/src/hasp/hasp_attribute.h
@@ -433,6 +433,7 @@ _HASP_ATTRIBUTE(SCALE_END_LINE_WIDTH, scale_end_line_width, lv_style_int_t)
 #define ATTR_COMMENT 62559
 #define ATTR_TAG 7866
 #define ATTR_JSONL 61604
+#define ATTR_MODE_FIXED 35736
 
 // methods
 #define ATTR_DELETE 50027

--- a/src/hasp/hasp_event.cpp
+++ b/src/hasp/hasp_event.cpp
@@ -836,6 +836,7 @@ void cpicker_event_handler(lv_obj_t* obj, lv_event_t event)
 
     /* Get the new value */
     lv_color_t color = lv_cpicker_get_color(obj);
+    lv_cpicker_color_mode_t mode = lv_cpicker_get_color_mode(obj);
 
     if(hasp_event_id == HASP_EVENT_CHANGED && last_color_sent.full == color.full) return; // same value as before
 
@@ -845,17 +846,19 @@ void cpicker_event_handler(lv_obj_t* obj, lv_event_t event)
         Parser::get_event_name(hasp_event_id, eventname, sizeof(eventname));
 
         lv_color32_t c32;
+        lv_color_hsv_t hsv;
         c32.full        = lv_color_to32(color);
+        hsv             = lv_color_rgb_to_hsv(c32.ch.red, c32.ch.green, c32.ch.blue);
         last_color_sent = color;
 
         if(const char* tag = my_obj_get_tag(obj))
             snprintf_P(data, sizeof(data),
-                       PSTR("{\"event\":\"%s\",\"color\":\"#%02x%02x%02x\",\"r\":%d,\"g\":%d,\"b\":%d,\"tag\":%s}"),
-                       eventname, c32.ch.red, c32.ch.green, c32.ch.blue, c32.ch.red, c32.ch.green, c32.ch.blue, tag);
+                       PSTR("{\"event\":\"%s\",\"color\":\"#%02x%02x%02x\",\"r\":%d,\"g\":%d,\"b\":%d,\"h\":%d,\"s\":%d,\"v\":%d,\"tag\":%s}"),
+                       eventname, c32.ch.red, c32.ch.green, c32.ch.blue, c32.ch.red, c32.ch.green, c32.ch.blue, hsv.h, hsv.s, hsv.v, tag);
         else
             snprintf_P(data, sizeof(data),
-                       PSTR("{\"event\":\"%s\",\"color\":\"#%02x%02x%02x\",\"r\":%d,\"g\":%d,\"b\":%d}"), eventname,
-                       c32.ch.red, c32.ch.green, c32.ch.blue, c32.ch.red, c32.ch.green, c32.ch.blue);
+                       PSTR("{\"event\":\"%s\",\"color\":\"#%02x%02x%02x\",\"r\":%d,\"g\":%d,\"b\":%d,\"h\":%d,\"s\":%d,\"v\":%d}"), eventname,
+                       c32.ch.red, c32.ch.green, c32.ch.blue, c32.ch.red, c32.ch.green, c32.ch.blue, hsv.h, hsv.s, hsv.v);
     }
     event_send_object_data(obj, data);
 


### PR DESCRIPTION
1. Add support for new attributes:
    -  `mode` is a read/write attribute which has a value of `hue`, `saturation`, or `value` and exposes `lv_cpicker_get_color_mode`/`lv_cpicker_set_color_mode`.
    - `mode_fixed` is a read/write Boolean attribute and exposes `lv_cpicker_get_color_mode_fixed`/`lv_cpicker_set_color_mode_fixed`
2. MQTT status responses include `h`, `s`, and `v` attributes from `cpicker`.

``` json
{
  "id": 4,
  "parentid": 2,
  "obj": "cpicker",
  "x": 25,
  "y": 5,
  "w": 180,
  "h": 180,
  "mode_fixed": true
}
```