### PR TITLE
Comment out LV_FONT_DEFAULT to allow custom builds to compile

### DIFF
--- a/include/user_config_override-template.h
+++ b/include/user_config_override-template.h
@@ -134,7 +134,7 @@
 // #define HASP_FONT_SIZE_4 48
 // #define HASP_FONT_SIZE_5 12
 
-#define LV_FONT_DEFAULT &HASP_FONT_1
+// #define LV_FONT_DEFAULT &HASP_FONT_1
 
 /***************************************************
  *        GPIO Settings


### PR DESCRIPTION
You can no longer have the LV_FONT_DEFAULT defined, so I have commented it out in the template so that other users will know to do the same if they try and create a user_config_override.h file.

[Discussion #450 ]
[Discussion #502 ]