### PR TITLE
Add 4MB variant for Makerfabs ESP32 TFT Touch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
           - out: m5stack
             env: m5stack-core2
           - out: makerfabs
-            env: "makerfabs-tft35-cap -e makerfabs-s3-tft35-spi -e makerfabs-s3-tft40-rgb -e makerfabs-s3-tft43-rgb"
+            env: "makerfabs-tft35-cap_4MB -e makerfabs-tft35-cap_16MB -e makerfabs-s3-tft35-spi -e makerfabs-s3-tft40-rgb -e makerfabs-s3-tft43-rgb"
           - out: panlee
             env: "panlee-zw3d95ce01s-ar-4848_16MB -e panlee-zw3d95ce01s-ur-4848_16MB"
           - out: sunton

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Run PlatformIO
       run: pio run -e az-touch-mod-esp32_ili9341_4MB -e az-touch-mod-esp32_ili9341_8MB
     - name: Run PlatformIO
-      run: pio run -e makerfabs-tft35-cap
+      run: pio run -e makerfabs-tft35-cap_4MB -e makerfabs-tft35-cap_16MB
     - name: Run PlatformIO
       run: pio run -e yeacreate-nscreen32 -e
     - name: Run PlatformIO

--- a/platformio_override-template.ini
+++ b/platformio_override-template.ini
@@ -53,7 +53,8 @@ extra_default_envs =
     ; m5stack-core2
     ; m5stack-tough
     ; makerfabs-s3-tft35-spi
-    ; makerfabs-tft35-cap
+    ; makerfabs-tft35-cap_16MB
+    ; makerfabs-tft35-cap_4MB
     ; makerfabs-tft-s2_ili9488
     ; nodemcu32s-raspi
     ; s2-mini-esp32s2_ili9341

--- a/user_setups/esp32/makerfabs-tft35-cap.ini
+++ b/user_setups/esp32/makerfabs-tft35-cap.ini
@@ -4,8 +4,8 @@
 ;               - FT6236 touch controller           ;
 ;***************************************************;
 
-[env:makerfabs-tft35-cap]
-extends = arduino_esp32_v2, flash_16mb
+[makerfabs-tft35-cap]
+extends = arduino_esp32_v2
 board = esp32dev
 
 build_flags =
@@ -39,3 +39,9 @@ lib_deps =
     ${arduino_esp32_v2.lib_deps}
     ${tft_espi.lib_deps}
     ${ft6336.lib_deps}
+
+[env:makerfabs-tft35-cap_4MB]
+extends = makerfabs-tft35-cap, flash_4mb
+
+[env:makerfabs-tft35-cap_16MB]
+extends = makerfabs-tft35-cap, flash_16mb


### PR DESCRIPTION
My Makerfabs ESP32 TFT Touch, v1.1 on the silkscreen, purchased in October 2020, has a 4MB flash as reported by esptool flash_id:
  Manufacturer: 20
  Device: 4016
  Detected flash size: 4MB

Add a makerfabs-tft35-cap_4MB variant, and rename makerfabs-tft35-cap to makerfabs-tft35-cap_16MB.