### PR TITLE
Adding system scripts that are automatically executed when idle level is changed

### DIFF
--- a/src/hasp/hasp_dispatch.cpp
+++ b/src/hasp/hasp_dispatch.cpp
@@ -1357,10 +1357,19 @@ void dispatch_idle(const char*, const char* payload, uint8_t source)
         uint8_t state = HASP_SLEEP_LAST;
         if(!strcmp_P(payload, "off")) {
             hasp_set_sleep_state(HASP_SLEEP_OFF);
+            if(HASP_FS.exists("L:/idle_off.cmd")) {
+                dispatch_run_script(NULL, "L:/idle_off.cmd", TAG_HASP);
+            };
         } else if(!strcmp_P(payload, "short")) {
             hasp_set_sleep_state(HASP_SLEEP_SHORT);
+            if(HASP_FS.exists("L:/idle_short.cmd")) {
+                dispatch_run_script(NULL, "L:/idle_short.cmd", TAG_HASP);
+            };
         } else if(!strcmp_P(payload, "long")) {
             hasp_set_sleep_state(HASP_SLEEP_LONG);
+            if(HASP_FS.exists("L:/idle_long.cmd")) {
+                dispatch_run_script(NULL, "L:/idle_long.cmd", TAG_HASP);
+            };
         } else {
             LOG_WARNING(TAG_MSGR, F("Invalid idle value %s"), payload);
             return;


### PR DESCRIPTION
Adding additional system scripts that are automatically executed when the idle level is changed.

* idle_off.cmd
* idle_short.cmd
* idle_long.cmd

In example this scripts can use to easy control the backlight or change page

* idle_off.cmd

```
backlight {"state": true, "brightness": 255}
moodlight {"state": false}
```

* idle_short.cmd

```
backlight {"state": "on", "brightness": 50}
```

* idle_long.cmd

```
backlight {"state": false, "brightness": 5}
moodlight {"state": true, "color":"green"}
```