### PR TITLE
Fix #534 ILI9486 Failed to start: src/drv/tft/tft_driver_lovyangfx.cpp

### DIFF
--- a/src/drv/tft/tft_driver_lovyangfx.cpp
+++ b/src/drv/tft/tft_driver_lovyangfx.cpp
@@ -298,6 +298,11 @@ lgfx::Panel_Device* LovyanGfx::_init_panel(lgfx::IBus* bus)
             LOG_VERBOSE(TAG_TFT, F("Panel_ILI9481_b"));
             break;
         }
+        case TFT_PANEL_ILI9486: {
+            panel = new lgfx::Panel_ILI9486();
+            LOG_VERBOSE(TAG_TFT, F("Panel_ILI9486"));
+            break;
+        }
         case TFT_PANEL_ILI9488: {
             panel = new lgfx::Panel_ILI9488();
             LOG_VERBOSE(TAG_TFT, F("Panel_ILI9488"));


### PR DESCRIPTION
Fix for #534
After compiling at least now openHASP starts 👍 and I can access over WIFI.
I still have issues with this driver, only tft_espi works but that is not related to this fatal error.