### PR TITLE
Allow long WiFi passwords in the GUI

### DIFF
--- a/src/hasp_oobe.cpp
+++ b/src/hasp_oobe.cpp
@@ -213,7 +213,7 @@ static void oobeSetupSsid(void)
     lv_obj_set_style_local_text_font(pwd_ta, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, defaultfont);
 
     lv_textarea_set_text(pwd_ta, "");
-    lv_textarea_set_max_length(pwd_ta, 32);
+    lv_textarea_set_max_length(pwd_ta, MAX_PASSWORD_LENGTH);
     lv_textarea_set_pwd_mode(pwd_ta, true);
     lv_textarea_set_one_line(pwd_ta, true);
     lv_textarea_set_cursor_hidden(pwd_ta, true);


### PR DESCRIPTION
In https://github.com/HASwitchPlate/openHASP/pull/71 support for longer WiFi passwords was introduced but it was not extended to the GUI editor which is still limited to 32 characters. Tested, works :)