### PR TITLE
always run idle scripts when sleep state changes

### DIFF
--- a/src/hasp/hasp.cpp
+++ b/src/hasp/hasp.cpp
@@ -119,20 +119,17 @@ HASP_ATTRIBUTE_FAST_MEM void hasp_update_sleep_state()
     if(sleepTimeLong > 0 && idle >= (sleepTimeShort + sleepTimeLong)) {
         if(hasp_sleep_state != HASP_SLEEP_LONG) {
             gui_hide_pointer(true);
-            hasp_sleep_state = HASP_SLEEP_LONG;
-            dispatch_idle_state(HASP_SLEEP_LONG);
+            hasp_set_sleep_state(HASP_SLEEP_LONG, TAG_MAIN);
         }
     } else if(sleepTimeShort > 0 && idle >= sleepTimeShort) {
         if(hasp_sleep_state != HASP_SLEEP_SHORT) {
             gui_hide_pointer(true);
-            hasp_sleep_state = HASP_SLEEP_SHORT;
-            dispatch_idle_state(HASP_SLEEP_SHORT);
+            hasp_set_sleep_state(HASP_SLEEP_SHORT, TAG_MAIN);
         }
     } else {
         if(hasp_sleep_state != HASP_SLEEP_OFF) {
             gui_hide_pointer(false);
-            hasp_sleep_state = HASP_SLEEP_OFF;
-            dispatch_idle_state(HASP_SLEEP_OFF);
+            hasp_set_sleep_state(HASP_SLEEP_OFF, TAG_MAIN);
         }
     }
 }
@@ -147,18 +144,21 @@ uint8_t hasp_get_sleep_state()
     return hasp_sleep_state;
 }
 
-void hasp_set_sleep_state(uint8_t state)
+void hasp_set_sleep_state(uint8_t state, uint8_t source)
 {
     switch(state) {
         case HASP_SLEEP_LONG:
             hasp_set_sleep_offset(sleepTimeShort + sleepTimeLong);
+            dispatch_run_script(NULL, "L:/idle_long.cmd", source);
             break;
         case HASP_SLEEP_SHORT:
             hasp_set_sleep_offset(sleepTimeShort);
+            dispatch_run_script(NULL, "L:/idle_short.cmd", source);
             break;
         case HASP_SLEEP_OFF:
             hasp_set_sleep_offset(0);
             // hasp_set_wakeup_touch(false);
+            dispatch_run_script(NULL, "L:/idle_off.cmd", source);
             break;
         default:
             return;

--- a/src/hasp/hasp.h
+++ b/src/hasp/hasp.h
@@ -79,7 +79,7 @@ lv_font_t* hasp_get_font(uint8_t fontid);
 HASP_ATTRIBUTE_FAST_MEM void hasp_update_sleep_state();
 void hasp_get_sleep_payload(uint8_t state, char* payload);
 uint8_t hasp_get_sleep_state();
-void hasp_set_sleep_state(uint8_t state);
+void hasp_set_sleep_state(uint8_t state, uint8_t source);
 void hasp_get_sleep_time(uint16_t& short_time, uint16_t& long_time);
 void hasp_set_sleep_time(uint16_t short_time, uint16_t long_time);
 void hasp_set_sleep_offset(uint32_t offset);

--- a/src/hasp/hasp_dispatch.cpp
+++ b/src/hasp/hasp_dispatch.cpp
@@ -1356,14 +1356,11 @@ void dispatch_idle(const char*, const char* payload, uint8_t source)
     if(payload && strlen(payload)) {
         uint8_t state = HASP_SLEEP_LAST;
         if(!strcmp_P(payload, "off")) {
-            hasp_set_sleep_state(HASP_SLEEP_OFF);
-            dispatch_run_script(NULL, "L:/idle_off.cmd", source);
+            hasp_set_sleep_state(HASP_SLEEP_OFF, source);
         } else if(!strcmp_P(payload, "short")) {
-            hasp_set_sleep_state(HASP_SLEEP_SHORT);
-            dispatch_run_script(NULL, "L:/idle_short.cmd", source);
+            hasp_set_sleep_state(HASP_SLEEP_SHORT, source);
         } else if(!strcmp_P(payload, "long")) {
-            hasp_set_sleep_state(HASP_SLEEP_LONG);
-            dispatch_run_script(NULL, "L:/idle_long.cmd", source);
+            hasp_set_sleep_state(HASP_SLEEP_LONG, source);
         } else {
             LOG_WARNING(TAG_MSGR, F("Invalid idle value %s"), payload);
             return;


### PR DESCRIPTION
The idle scripts are not executed when the sleep state changes based on the system timer. Make things consistent.