### PR TITLE
use one allocation size for DynamicJsonDocument settings

### DIFF
--- a/src/hasp_config.cpp
+++ b/src/hasp_config.cpp
@@ -354,7 +354,7 @@ void configWrite()
     settingsChanged = F(D_CONFIG_CHANGED);
 
     /* Read Config File */
-    DynamicJsonDocument doc(8 * 256);
+    DynamicJsonDocument doc(MAX_CONFIG_JSON_ALLOC_SIZE);
     LOG_TRACE(TAG_CONF, F(D_FILE_LOADING), configFile.c_str());
     configRead(doc, false);
     LOG_INFO(TAG_CONF, F(D_FILE_LOADED), configFile.c_str());
@@ -515,7 +515,7 @@ void configWrite()
 
 void configSetup()
 {
-    DynamicJsonDocument settings(1024 + 512);
+    DynamicJsonDocument settings(MAX_CONFIG_JSON_ALLOC_SIZE);
 
     for(uint32_t i = 0; i < 2; i++) {
         if(i == 0) {

--- a/src/hasp_config.h
+++ b/src/hasp_config.h
@@ -8,6 +8,8 @@
 
 #include "hasplib.h"
 
+#define MAX_CONFIG_JSON_ALLOC_SIZE (2048)
+
 /* ===== Default Event Processors ===== */
 void configSetup(void);
 void configLoop(void);

--- a/src/sys/svc/hasp_http.cpp
+++ b/src/sys/svc/hasp_http.cpp
@@ -561,7 +561,7 @@ static void webHandleApi()
 { // http://plate01/api
     if(!http_is_authenticated("api")) return;
 
-    DynamicJsonDocument doc(2048);
+    DynamicJsonDocument doc(max(MAX_CONFIG_JSON_ALLOC_SIZE, 2048));
     String contentType = http_get_content_type(F(".json"));
     String endpoint((char*)0);
     endpoint = webServer.pathArg(0);
@@ -1109,7 +1109,7 @@ static inline int handleFilesystemFile(String path)
         configFile = FPSTR(FP_HASP_CONFIG_FILE);
 
         if(path.endsWith(configFile.c_str())) { // "//config.json" is also a valid path!
-            DynamicJsonDocument settings(2048);
+            DynamicJsonDocument settings(MAX_CONFIG_JSON_ALLOC_SIZE);
             DeserializationError error = configParseFile(configFile, settings);
 
             if(error) return 500; // Internal Server Error

--- a/src/sys/svc/hasp_http_async.cpp
+++ b/src/sys/svc/hasp_http_async.cpp
@@ -934,7 +934,7 @@ int handleFileRead(AsyncWebServerRequest* request, String path)
 
         if(!strncasecmp(file.name(), configFile.c_str(), configFile.length())) {
             file.close();
-            DynamicJsonDocument settings(8 * 256);
+            DynamicJsonDocument settings(MAX_CONFIG_JSON_ALLOC_SIZE);
             DeserializationError error = configParseFile(configFile, settings);
 
             if(error) return 500; // Internal Server Error


### PR DESCRIPTION
The problem was detected in configSetup() - the configuration was read only from EEPROM but not from SPI flash FS.

Cleanup things and use only one allocation size for both write and read configuration operations.