### PR TITLE
Added support for Wizee (Elecrow) 2.8 WZ2432R028 ESP32 Display

### DIFF
--- a/platformio_override-template.ini
+++ b/platformio_override-template.ini
@@ -70,6 +70,7 @@ extra_default_envs =
     ; wt32-sc01-plus_8MB
     ; wt-86-32-3zw1
     ; yeacreate-nscreen32
+    ; wz2432r028
 ;endregion
 
 ;region -- Define your local COM ports for each environment ---

--- a/user_setups/esp32/wz2432r028.ini
+++ b/user_setups/esp32/wz2432r028.ini
@@ -1,0 +1,48 @@
+;***************************************************;
+;   Wizee WZ2432R028 ESP32-WROOM custom dev board   ;
+;               - ILI9341 TFT SPI 4-WIRE            ;
+;               - XPT2046 touch controller          ;
+;***************************************************;
+
+[env:wz2432r028]
+extends = arduino_esp32_v2, flash_4mb
+board = denky32
+upload_speed = 921600
+
+build_flags =
+    ${arduino_esp32_v2.build_flags}
+    ${esp32.no_ps_ram}
+
+;region -- TFT_eSPI build options ------------------------
+    ${esp32.hspi}  
+    -D USER_SETUP_LOADED=1
+    -D ILI9341_DRIVER=1
+    -D TFT_ROTATION=0 ; 0=0, 1=90, 2=180 or 3=270 degree
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=320
+
+    -D TFT_DC=2
+    -D TFT_CS=15
+    -D TFT_SCLK=14
+    -D TFT_MOSI=13
+    -D TFT_MISO=12
+    -D TFT_BCKL=27
+    -D SUPPORT_TRANSACTIONS
+    -D SPI_FREQUENCY=65000000
+    -D SPI_READ_FREQUENCY=20000000
+    -D TOUCH_DRIVER=0x2046 ; XPT2606 Resistive touch panel driver
+    -D HASP_USE_LGFX_TOUCH=1
+    -D TOUCH_CS=33
+    -D TOUCH_SCLK=25
+    -D TOUCH_MOSI=32
+    -D TOUCH_MISO=39
+    -D TOUCH_SDA=-1
+    -D TOUCH_SCL=-1
+    -D TOUCH_IRQ=36
+    -D SPI_TOUCH_FREQUENCY=2500000
+
+; -- Debugging options -----------------------------
+;   -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE
+lib_deps =
+    ${arduino_esp32_v2.lib_deps}
+    ${tft_espi.lib_deps}


### PR DESCRIPTION
Tested, working well. https://www.elecrow.com/esp32-display-2-8-inch-hmi-display-spi-tft-lcd-touch-screen.html