### PR TITLE
Fix MacOS build

### DIFF
--- a/tools/osx_build_extra.py
+++ b/tools/osx_build_extra.py
@@ -1,6 +1,7 @@
 Import("env")
 
-env.Replace(CC="gcc-10", CXX="g++-10")
+#env.Replace(CC="gcc-10", CXX="g++-10")
+env.Replace(CC="gcc-12", CXX="g++-12")
 
 env.Replace(BUILD_SCRIPT="tools/osx_build_script.py")
 

--- a/user_setups/darwin_sdl/darwin_sdl_64bits.ini
+++ b/user_setups/darwin_sdl/darwin_sdl_64bits.ini
@@ -58,8 +58,10 @@ build_flags =
   -lm
   -lpthread
   ; MacOS with Homebrew
-  -I/usr/local/include
-  -L/usr/local/lib
+  ;-I/usr/local/include
+  ;-L/usr/local/lib
+  -I/opt/homebrew/include
+  -L/opt/homebrew/lib
   -DTARGET_OS_MAC=1
 
 lib_deps =
@@ -77,6 +79,7 @@ lib_ignore =
   ArduinoLog
   lv_lib_qrcode
   ETHSPI
+  freetype
 
 build_src_filter =
   +<*>


### PR DESCRIPTION
Fix mac build:
- Change compiler version so it works with newer MacOS
- Fix library paths
- Exclude freetype which creates a build error