### PR TITLE
Corrected environment names for huzzah32-v2-* boards

### DIFF
--- a/user_setups/esp32/huzzah32-v2-featherwing-24-v2.ini
+++ b/user_setups/esp32/huzzah32-v2-featherwing-24-v2.ini
@@ -5,7 +5,7 @@
 ;               - TSC2007 touch controller          ;
 ;***************************************************;
 
-[env:huzzah32-featherwing-24-v2]
+[env:huzzah32-v2-featherwing-24-v2]
 extends = arduino_esp32_v2, flash_4mb
 board = featheresp32
 

--- a/user_setups/esp32/huzzah32-v2-featherwing-35-v2.ini
+++ b/user_setups/esp32/huzzah32-v2-featherwing-35-v2.ini
@@ -5,7 +5,7 @@
 ;               - TSC2007 touch controller          ;
 ;***************************************************;
 
-[env:huzzah32-v2-featherwing-35]
+[env:huzzah32-v2-featherwing-35-v2]
 extends = arduino_esp32_v2, flash_4mb
 board = featheresp32
 


### PR DESCRIPTION
Corrected typos in the environment names which caused the tests to fail.