### PR TITLE
Allow more time for http get

### DIFF
--- a/src/hasp/hasp.cpp
+++ b/src/hasp/hasp.cpp
@@ -121,21 +121,18 @@ HASP_ATTRIBUTE_FAST_MEM void hasp_update_sleep_state()
             gui_hide_pointer(true);
             hasp_sleep_state = HASP_SLEEP_LONG;
             dispatch_idle_state(HASP_SLEEP_LONG);
-            dispatch_run_script(NULL, "L:/idle_long.cmd", TAG_MAIN);
         }
     } else if(sleepTimeShort > 0 && idle >= sleepTimeShort) {
         if(hasp_sleep_state != HASP_SLEEP_SHORT) {
             gui_hide_pointer(true);
             hasp_sleep_state = HASP_SLEEP_SHORT;
             dispatch_idle_state(HASP_SLEEP_SHORT);
-            dispatch_run_script(NULL, "L:/idle_short.cmd", TAG_MAIN);
         }
     } else {
         if(hasp_sleep_state != HASP_SLEEP_OFF) {
             gui_hide_pointer(false);
             hasp_sleep_state = HASP_SLEEP_OFF;
             dispatch_idle_state(HASP_SLEEP_OFF);
-            dispatch_run_script(NULL, "L:/idle_off.cmd", TAG_MAIN);
         }
     }
 }

--- a/src/hasp/hasp.cpp
+++ b/src/hasp/hasp.cpp
@@ -121,18 +121,21 @@ HASP_ATTRIBUTE_FAST_MEM void hasp_update_sleep_state()
             gui_hide_pointer(true);
             hasp_sleep_state = HASP_SLEEP_LONG;
             dispatch_idle_state(HASP_SLEEP_LONG);
+            dispatch_run_script(NULL, "L:/idle_long.cmd", TAG_MAIN);
         }
     } else if(sleepTimeShort > 0 && idle >= sleepTimeShort) {
         if(hasp_sleep_state != HASP_SLEEP_SHORT) {
             gui_hide_pointer(true);
             hasp_sleep_state = HASP_SLEEP_SHORT;
             dispatch_idle_state(HASP_SLEEP_SHORT);
+            dispatch_run_script(NULL, "L:/idle_short.cmd", TAG_MAIN);
         }
     } else {
         if(hasp_sleep_state != HASP_SLEEP_OFF) {
             gui_hide_pointer(false);
             hasp_sleep_state = HASP_SLEEP_OFF;
             dispatch_idle_state(HASP_SLEEP_OFF);
+            dispatch_run_script(NULL, "L:/idle_off.cmd", TAG_MAIN);
         }
     }
 }

--- a/src/hasp/hasp_attribute.cpp
+++ b/src/hasp/hasp_attribute.cpp
@@ -1346,7 +1346,7 @@ static hasp_attribute_type_t special_attribute_src(lv_obj_t* obj, const char* pa
 #if HASP_USE_WIFI > 0 || HASP_USE_ETHERNET > 0
             HTTPClient http;
             http.begin(payload);
-            http.setTimeout(1000);
+            http.setTimeout(5000);
             http.setConnectTimeout(5000);
 
             // const char* hdrs[] = {"Content-Type"};


### PR DESCRIPTION
When specifying a URL for image src, we get a timeout already after 1 second. Some image providers (like security cameras) are taking more than 1 second. This simple change solves that.

(sorry for the 2 extra commits, mixed up branches)