### PR TITLE
re-enable idle scripts

### DIFF
--- a/src/hasp/hasp.cpp
+++ b/src/hasp/hasp.cpp
@@ -121,21 +121,21 @@ HASP_ATTRIBUTE_FAST_MEM void hasp_update_sleep_state()
             gui_hide_pointer(true);
             hasp_sleep_state = HASP_SLEEP_LONG;
             dispatch_idle_state(HASP_SLEEP_LONG);
-            dispatch_run_script(NULL, "L:/idle_long.cmd", TAG_MAIN);
+            dispatch_run_script(NULL, "L:/idle_long.cmd", TAG_HASP);
         }
     } else if(sleepTimeShort > 0 && idle >= sleepTimeShort) {
         if(hasp_sleep_state != HASP_SLEEP_SHORT) {
             gui_hide_pointer(true);
             hasp_sleep_state = HASP_SLEEP_SHORT;
             dispatch_idle_state(HASP_SLEEP_SHORT);
-            dispatch_run_script(NULL, "L:/idle_short.cmd", TAG_MAIN);
+            dispatch_run_script(NULL, "L:/idle_short.cmd", TAG_HASP);
         }
     } else {
         if(hasp_sleep_state != HASP_SLEEP_OFF) {
             gui_hide_pointer(false);
             hasp_sleep_state = HASP_SLEEP_OFF;
             dispatch_idle_state(HASP_SLEEP_OFF);
-            dispatch_run_script(NULL, "L:/idle_off.cmd", TAG_MAIN);
+            dispatch_run_script(NULL, "L:/idle_off.cmd", TAG_HASP);
         }
     }
 }

--- a/src/hasp/hasp.cpp
+++ b/src/hasp/hasp.cpp
@@ -121,18 +121,21 @@ HASP_ATTRIBUTE_FAST_MEM void hasp_update_sleep_state()
             gui_hide_pointer(true);
             hasp_sleep_state = HASP_SLEEP_LONG;
             dispatch_idle_state(HASP_SLEEP_LONG);
+            dispatch_run_script(NULL, "L:/idle_long.cmd", TAG_MAIN);
         }
     } else if(sleepTimeShort > 0 && idle >= sleepTimeShort) {
         if(hasp_sleep_state != HASP_SLEEP_SHORT) {
             gui_hide_pointer(true);
             hasp_sleep_state = HASP_SLEEP_SHORT;
             dispatch_idle_state(HASP_SLEEP_SHORT);
+            dispatch_run_script(NULL, "L:/idle_short.cmd", TAG_MAIN);
         }
     } else {
         if(hasp_sleep_state != HASP_SLEEP_OFF) {
             gui_hide_pointer(false);
             hasp_sleep_state = HASP_SLEEP_OFF;
             dispatch_idle_state(HASP_SLEEP_OFF);
+            dispatch_run_script(NULL, "L:/idle_off.cmd", TAG_MAIN);
         }
     }
 }


### PR DESCRIPTION
See https://github.com/HASwitchPlate/openHASP/issues/618

The idle scripts were inoperative since a recent commit.

Not sure if what I claim is true, but this is my interpretation: Since:
* ```dispatch_idle_state()``` seems to be called also when a state situation is requested (```dispatch_current_state()```)
* ```dispatch_idle()``` seems to be called only upon startup
* ```hasp_set_sleep_state()``` seems to be deprecated

and we want the scripts to be called only when the state changes, I decided to put the scripts directly in the function that detects the changes: ```hasp_update_sleep_state()```