### PR TITLE
wireguard - allow to set hostname for the remote peer

### DIFF
--- a/src/sys/net/hasp_wireguard.cpp
+++ b/src/sys/net/hasp_wireguard.cpp
@@ -12,7 +12,7 @@
 
 char wg_ip[16] = WIREGUARD_IP;
 char wg_private_key[45] = WIREGUARD_PRIVATE_KEY;
-char wg_ep_ip[16] = WIREGUARD_EP_IP;
+char wg_ep_ip[40] = WIREGUARD_EP_IP;
 uint16_t wg_ep_port = WIREGUARD_EP_PORT;
 char wg_ep_public_key[45] = WIREGUARD_EP_PUBLIC_KEY;
 static WireGuard wg;

--- a/src/sys/svc/hasp_http.cpp
+++ b/src/sys/svc/hasp_http.cpp
@@ -2357,7 +2357,7 @@ static void http_handle_wireguard()
 </div>
 <div class="row">
 <div class="col-25"><label for="host" v-t="'wg.host'"></label></div>
-<div class="col-75"><input type="text" id="host" maxlength="15" placeholder="Remote IP" v-model="config.wg.host" pattern="^((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])$"></div>
+<div class="col-75"><input type="text" id="host" maxlength="40" placeholder="Remote IP" v-model="config.wg.host"></div>
 </div>
 <div class="row">
 <div class="col-25"><label for="port" v-t="'wg.port'"></label></div>


### PR DESCRIPTION
WireGuard-ESP32 library uses lwip_getaddrinfo() call to resolve IP/hostname string, so it should work.