### PR TITLE
Little wireguard cleanups

### DIFF
--- a/src/lang/lang.h
+++ b/src/lang/lang.h
@@ -11,7 +11,7 @@
 #endif
 
 //  language independent defines
-#define D_PASSWORD_MASK "********"
+#define D_PASSWORD_MASK "********" // beware: webui have this string hardcoded!
 #define D_BULLET "    * "
 #define D_MANUFACTURER "openHASP"
 #define D_BACK_ICON "&#8617; "

--- a/src/sys/net/hasp_wireguard.cpp
+++ b/src/sys/net/hasp_wireguard.cpp
@@ -103,7 +103,6 @@ bool wgSetConfig(const JsonObject& settings)
 
     configOutput(settings, TAG_WG);
     bool changed = false;
-    bool changed_privkey = false;
 
     changed |= configSet((char *)wg_ip, sizeof(wg_ip), settings[FPSTR(FP_CONFIG_VPN_IP)], F("wgIp"));
     if(!settings[FPSTR(FP_CONFIG_PRIVATE_KEY)].isNull() &&
@@ -113,15 +112,15 @@ bool wgSetConfig(const JsonObject& settings)
         wg_private_key[sizeof(wg_private_key)-1] = '\0';
         nvsUpdateString(preferences, FP_CONFIG_PRIVATE_KEY, settings[FPSTR(FP_CONFIG_PRIVATE_KEY)]);
     }
-    changed |= changed_privkey;
     changed |= configSet((char *)wg_ep_ip, sizeof(wg_ep_ip), settings[FPSTR(FP_CONFIG_HOST)], F("wgEpIp"));
     changed |= configSet(wg_ep_port, settings[FPSTR(FP_CONFIG_PORT)], F("wgEpPort"));
     changed |= configSet((char *)wg_ep_public_key, sizeof(wg_ep_public_key), settings[FPSTR(FP_CONFIG_PUBLIC_KEY)], F("wgEpPubKey"));
 
-    if (changed && network_is_connected()) {
-        wg.end();
-        wg_network_connected();
-    }
+// may reset device...
+//    if (changed && network_is_connected()) {
+//        wg.end();
+//        wg_network_connected();
+//    }
 
     return changed;
 }

--- a/src/sys/svc/hasp_http.cpp
+++ b/src/sys/svc/hasp_http.cpp
@@ -2353,7 +2353,7 @@ static void http_handle_wireguard()
 </div>
 <div class="row gap">
 <div class="col-25"><label for="privkey" v-t="'wg.privkey'"></label></div>
-<div class="col-75"><input type="password" id="privkey" maxlength="44" placeholder="Private Key" v-model="config.wg.privkey" pattern="^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}={2})$"></div>
+<div class="col-75"><input type="password" id="privkey" maxlength="44" placeholder="Private Key" v-model="config.wg.privkey" pattern="^((?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}={2})|(\*\*\*\*\*\*\*\*))$"></div>
 </div>
 <div class="row">
 <div class="col-25"><label for="host" v-t="'wg.host'"></label></div>


### PR DESCRIPTION
- accept the password mask as valid input string in web ui
- do not set the new configuration immediatelly (use manual restart like for wifi)
