### PR TITLE
Handle HTTPS requests

### DIFF
--- a/src/hasp/hasp_attribute.cpp
+++ b/src/hasp/hasp_attribute.cpp
@@ -1348,8 +1348,11 @@ static hasp_attribute_type_t special_attribute_src(lv_obj_t* obj, const char* pa
 #if defined(ARDUINO) && defined(ARDUINO_ARCH_ESP32)
 #if HASP_USE_WIFI > 0 || HASP_USE_ETHERNET > 0
             HTTPClient http;
-            // http.begin(payload, (const char*)rootca_crt_bundle_start);
-            http.begin(payload);
+            if (payload == strstr_P(payload, PSTR("https://"))) {
+                http.begin(payload, nullptr);
+            } else {
+                http.begin(payload);
+            }
             http.setTimeout(5000);
             http.setConnectTimeout(5000);
 


### PR DESCRIPTION
This adds the ability for img.src to use https requests. It ignores certificates validation, but allows those using Home Assistant with https to get images delivered to the boards.

Note that https requires

```
platform = espressif32@5.3.0
```

or similar to work properly.