### PR TITLE
Fix to compile in MacOS 14

### DIFF
--- a/src/hasp_debug.cpp
+++ b/src/hasp_debug.cpp
@@ -29,7 +29,7 @@
 
 #if defined(POSIX)
 #include <unistd.h>
-#include <linux/limits.h>
+#include <limits.h>
 #define cwd getcwd
 #endif
 

--- a/src/main_pc.cpp
+++ b/src/main_pc.cpp
@@ -18,7 +18,7 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <pwd.h>
 #define cwd getcwd

--- a/tools/osx_build_extra.py
+++ b/tools/osx_build_extra.py
@@ -1,7 +1,7 @@
 Import("env")
 
 #env.Replace(CC="gcc-10", CXX="g++-10")
-env.Replace(CC="gcc-12", CXX="g++-12")
+env.Replace(CC="gcc-13", CXX="g++-13")
 
 env.Replace(BUILD_SCRIPT="tools/osx_build_script.py")
 


### PR DESCRIPTION
Recently https://github.com/HASwitchPlate/openHASP/pull/631 broke Darwin build

This PR fixes the situation and upgrades to MacOS 14 (Sonoma)