### PR TITLE
Allow overriding of LV_MEM_CUSTOM

### DIFF
--- a/include/lv_conf_v7.h
+++ b/include/lv_conf_v7.h
@@ -80,8 +80,10 @@ typedef int16_t lv_coord_t;
 #define LV_FS_SEEK(x, y) lv_fs_seek(x, y)
 #define _lv_img_decoder_t _lv_img_decoder
 
+#ifndef LV_MEM_CUSTOM
   /* 1: use custom malloc/free, 0: use the built-in `lv_mem_alloc` and `lv_mem_free` */
 #define LV_MEM_CUSTOM      0
+#endif
 #if LV_MEM_CUSTOM == 0
 /* Size of the memory used by `lv_mem_alloc` in bytes (>= 2kB)*/
 

--- a/include/lv_conf_v8.h
+++ b/include/lv_conf_v8.h
@@ -86,8 +86,10 @@ typedef int16_t lv_coord_t;
 /* LittelvGL's internal memory manager's settings.
  * The graphical objects and other related data are stored here. */
 
+#ifndef LV_MEM_CUSTOM
 /* 1: use custom malloc/free, 0: use the built-in `lv_mem_alloc` and `lv_mem_free` */
 #define LV_MEM_CUSTOM      0
+#endif
 #if LV_MEM_CUSTOM == 0
 /* Size of the memory used by `lv_mem_alloc` in bytes (>= 2kB)*/
 //#  define LV_MEM_SIZE    (32U * 1024U)


### PR DESCRIPTION
Right now, it is not possible to use `user_config_override.h` to set `#define LV_MEM_CUSTOM 1`.  Both `lv_conf_v7.h` and `lv_conf_v8.h` force the value to 0.

This PR makes it possible to override the value of LV_MEM_CUSTOM.

See the discussion around https://github.com/HASwitchPlate/openHASP/issues/676 for example.