### PR TITLE
Add support for 2424S012 (round display with ESP32-C3)

### DIFF
--- a/src/drv/tft/M5Stack.hpp
+++ b/src/drv/tft/M5Stack.hpp
@@ -17,7 +17,7 @@ Contributors:
 /----------------------------------------------------------------------------*/
 #pragma once
 
-#if defined(ARDUINO) && defined(LGFX_USE_V1)
+#if defined(ARDUINO) && defined(LGFX_USE_V1) && !defined(ESP32C3)
 
 #include "Arduino.h"
 #include "LovyanGFX.hpp"

--- a/src/drv/tft/M5Stack.hpp
+++ b/src/drv/tft/M5Stack.hpp
@@ -17,7 +17,7 @@ Contributors:
 /----------------------------------------------------------------------------*/
 #pragma once
 
-#if defined(ARDUINO) && defined(LGFX_USE_V1) && !defined(ESP32C3)
+#if defined(ARDUINO) && defined(LGFX_USE_V1) && !defined(CONFIG_IDF_TARGET_ESP32C3)
 
 #include "Arduino.h"
 #include "LovyanGFX.hpp"

--- a/src/drv/tft/tft_driver.h
+++ b/src/drv/tft/tft_driver.h
@@ -32,6 +32,7 @@ enum lv_hasp_obj_type_t {
     TFT_PANEL_RM68140,
     TFT_PANEL_RGB,
     TFT_PANEL_EPD,
+    TFT_PANEL_GC9A01,
     TFT_PANEL_LAST,
 };
 

--- a/src/drv/tft/tft_driver_lovyangfx.cpp
+++ b/src/drv/tft/tft_driver_lovyangfx.cpp
@@ -94,12 +94,12 @@ static lgfx::Bus_Parallel8* init_parallel_8_bus(Preferences* prefs, int8_t data_
     cfg.pin_rd               = prefs->getInt("rd", TFT_RD);
     cfg.pin_wr               = prefs->getInt("wr", TFT_WR);
     cfg.pin_rs               = prefs->getInt("rs", TFT_DC);
-#ifndef ESP32C3
+#ifndef CONFIG_IDF_TARGET_ESP32C3
     cfg.freq_write           = prefs->getUInt("write_freq", SPI_FREQUENCY);
 #endif 
 
 
-#if !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(ESP32C3)
+#if !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32C3)
     uint8_t port = prefs->getUInt("i2s_port", 0);
     switch(port) {
 #if SOC_I2S_NUM > 1

--- a/user_setups/esp32/ttgo-t-watch.ini
+++ b/user_setups/esp32/ttgo-t-watch.ini
@@ -1,0 +1,54 @@
+[ttgo-t-watch]
+
+extends = arduino_esp32_v2
+board = esp32dev
+
+build_flags =
+    ${arduino_esp32_v2.build_flags}
+    ${esp32.ps_ram}
+
+;region -- TFT_eSPI build options ------------------------
+    -D LGFX_USE_V1=1
+    -D HASP_USE_LGFX_TOUCH=1
+    -D ST7789_DRIVER=1
+    -D TFT_HEIGHT=240
+    -D TFT_WIDTH=240
+    -D TFT_DC=27
+    -D TFT_CS=5
+    -D TFT_MOSI=19
+    -D TFT_RST=-1 
+    -D TFT_SCLK=18
+    -D TFT_BCKL=12
+    -D SPI_FREQUENCY=40000000
+    -D I2C_TOUCH_ADDRESS=0x38
+    -D I2C_TOUCH_FREQUENCY=400000
+    -D TOUCH_DRIVER=0x6336
+    -D I2C_TOUCH_PORT=1
+    -D TOUCH_IRQ=38
+    -D TOUCH_RST=-1
+    -D TOUCH_SDA=23
+    -D TOUCH_SCL=32
+;endregion
+
+lib_deps =
+    ${arduino_esp32_v2.lib_deps}
+    ${lovyangfx.lib_deps}
+    ${ft6336.lib_deps}
+
+[env:ttgo-t-watch-2019]
+extends = ttgo-t-watch, flash_16mb
+
+build_flags =
+    ${ttgo-t-watch.build_flags}
+    -D HASP_MODEL="TTgo T-Watch 2019"
+    -D INVERT_COLORS=1
+
+[env:ttgo-t-watch-2020]
+extends = ttgo-t-watch, flash_16mb
+
+build_flags =
+    ${ttgo-t-watch.build_flags}
+    -D HASP_MODEL="TTgo T-Watch 2020"
+    -D TFT_ROTATION=0
+    ;-D TFT_ROTATION=2
+    -D TOUCH_OFFSET_ROTATION=4 ; 1=swap xy, 2=invert x, 4=inverty

--- a/user_setups/esp32c3/2424S012.ini
+++ b/user_setups/esp32c3/2424S012.ini
@@ -28,6 +28,7 @@ build_flags =
     -D TFT_DC=2
     -D TFT_CS=10
     -D TFT_BCKL=3
+    -D SERIAL_SPEED=-1 ;otherwise requires serial term to boot first time
 
 lib_deps =
     ${arduino_esp32s3_v2.lib_deps}

--- a/user_setups/esp32c3/2424S012.ini
+++ b/user_setups/esp32c3/2424S012.ini
@@ -1,6 +1,6 @@
 [env:2424S012]
 extends = arduino_esp32c3_v2, flash_4mb
-; Close enough
+; Close enough, sets it up to use USB-CDC rather than uart
 board = seeed_xiao_esp32c3 
 
 build_flags =
@@ -9,7 +9,6 @@ build_flags =
     ${esp32c3.no_ps_ram}
 
 ; Display configuration
-    -D ESP32C3=1
     -D LGFX_USE_V1=1
     -D HASP_USE_LGFX_TOUCH=1
     ;CST816S driver
@@ -33,4 +32,3 @@ build_flags =
 lib_deps =
     ${arduino_esp32s3_v2.lib_deps}
     ${lovyangfx.lib_deps}
-;    ${tft_espi.lib_deps}

--- a/user_setups/esp32c3/2424S012.ini
+++ b/user_setups/esp32c3/2424S012.ini
@@ -1,0 +1,36 @@
+[env:2424S012]
+extends = arduino_esp32c3_v2, flash_4mb
+; Close enough
+board = seeed_xiao_esp32c3 
+
+build_flags =
+    -D HASP_MODEL="ESP32-2424S012"
+    ${arduino_esp32c3_v2.build_flags}
+    ${esp32c3.no_ps_ram}
+
+; Display configuration
+    -D ESP32C3=1
+    -D LGFX_USE_V1=1
+    -D HASP_USE_LGFX_TOUCH=1
+    ;CST816S driver
+    -D TOUCH_DRIVER=0x816 
+    -D GC9A01_DRIVER=1
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=240
+    -D TOUCH_SDA=4
+    -D TOUCH_SCL=5
+    -D TOUCH_IRQ=0
+    -D TOUCH_RST=1
+    -D I2C_TOUCH_FREQUENCY=400000
+    -D I2C_TOUCH_PORT=0
+    -D I2C_TOUCH_ADDRESS=0x15
+    -D TFT_SCLK=6
+    -D TFT_MOSI=7
+    -D TFT_DC=2
+    -D TFT_CS=10
+    -D TFT_BCKL=3
+
+lib_deps =
+    ${arduino_esp32s3_v2.lib_deps}
+    ${lovyangfx.lib_deps}
+;    ${tft_espi.lib_deps}


### PR DESCRIPTION
Greetings. This adds configurations for:

- GC9A01 display driver (with LovyanGFX)
- CST816 touch driver (with LovyanGFX)
- 2424S012 module (includes ESP32-C3, GC9A01 display and CST816 touch driver)

This also changes the M5Stack and 8bit display files - I don't have hardware for these, so I wasn't able to test if these still work as expected. 

![IMG_20240426_000246076](https://github.com/HASwitchPlate/openHASP/assets/55005345/c1b4e3ac-46c5-482a-bd25-c3fdae2bc0a8)
