### PR TITLE
Add support for ThingPulse Color Kit Grande

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ extra_configs =
     user_setups/lcd_config.ini
     ; --  Base configurations per platform
     user_setups/esp32/_esp32.ini
+    user_setups/esp32/*.ini
     user_setups/esp32s2/_esp32s2.ini
     user_setups/esp32s3/_esp32s3.ini
     ; --  Put custom [env] files in this dir to be included in the build menu

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,6 @@ extra_configs =
     user_setups/lcd_config.ini
     ; --  Base configurations per platform
     user_setups/esp32/_esp32.ini
-    user_setups/esp32/*.ini
     user_setups/esp32s2/_esp32s2.ini
     user_setups/esp32s3/_esp32s3.ini
     ; --  Put custom [env] files in this dir to be included in the build menu

--- a/user_setups/esp32/thingpulse-color-kit-grande.ini
+++ b/user_setups/esp32/thingpulse-color-kit-grande.ini
@@ -1,0 +1,50 @@
+[env:thingpulse_color_kit_grande]
+extends = arduino_esp32_v2, flash_8mb
+board = esp32dev
+
+build_flags =
+    -D HASP_MODEL="ESP32 Touchdown"
+    ${arduino_esp32_v2.build_flags}
+    ${esp32.no_ps_ram}
+
+;region -- TFT_eSPI build options ------------------------
+    ${esp32.vspi}        ; Use VSPI hardware SPI bus
+    ;-D USER_SETUP_LOADED=1
+    -D LGFX_USE_V1=1
+    -D ILI9488_DRIVER=1
+    -D TFT_ROTATION=0 ; 0=0, 1=90, 2=180 or 3=270 degree
+    -D TFT_WIDTH=320
+    -D TFT_HEIGHT=480
+    -D TFT_MISO=19
+    -D TFT_MOSI=18
+    -D TFT_SCLK=05
+    -D TFT_CS=15
+    -D TFT_DC=2
+    -D TFT_RST=4
+    -D TFT_BL=32
+    -D TFT_BCKL=32
+    -D SUPPORT_TRANSACTIONS
+    -D TOUCH_DRIVER=0x6336 ; FT6336 Capacitive touch panel driver 
+    -D TOUCH_SDA=23
+    -D TOUCH_SCL=22
+    -D TOUCH_IRQ=27
+    -D TOUCH_RST=-1   ; not used
+    -D I2C_TOUCH_FREQUENCY=400000
+    -D I2C_TOUCH_ADDRESS=0x38
+    -D SPI_FREQUENCY=40000000
+    -D SPI_READ_FREQUENCY=20000000
+
+;endregion
+
+; -- Debugging options -----------------------------
+;   -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+
+lib_deps =
+    ${arduino_esp32_v2.lib_deps}
+    ${lovyangfx.lib_deps}
+    ${ft6336.lib_deps}
+
+lib_ignore =
+    ${env.lib_ignore}
+    ${arduino_esp32_v2.lib_ignore}
+    TFT_eSPI


### PR DESCRIPTION
Please add support for the ThingPulse Color Kit Grande:
https://thingpulse.com/product/esp32-wifi-color-display-kit-grande/

Characterstics:
- ESP32 Wrover (8MB Flash, 8MB SPRAM)
- 3.5″ 320×480  Color Display (ILI9488, TFT) with capacitive touch Interface (FT6236)
- Connector & charging circuitry for LiPo battery