### PR TITLE
Add support for Guition JC4827W543

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -112,7 +112,7 @@ lib_deps =
 
 [arduinogfx]
 lib_deps =
-    moononournation/GFX Library for Arduino@1.4.0  ; Update needs modification of custom PCA class
+    moononournation/GFX Library for Arduino@1.4.7  ; Update needs modification of custom PCA class
     ;git+https://github.com/moononournation/Arduino_GFX.git
 
 [tft_espi]

--- a/src/drv/tft/tft_driver_arduinogfx.cpp
+++ b/src/drv/tft/tft_driver_arduinogfx.cpp
@@ -85,6 +85,10 @@ void ArduinoGfx::init(int w, int h)
     /* More display class: https://github.com/moononournation/Arduino_GFX/wiki/Display-Class */
     tft = new Arduino_RGB_Display(w, h, rgbpanel, 0 /* rotation */, TFT_AUTO_FLUSH, bus, TFT_RST,
                                   st7701_type1_init_operations, sizeof(st7701_type1_init_operations));
+#elif(TFT_WIDTH == 480) && (TFT_HEIGHT == 272) && defined(NV3041A_DRIVER)
+    Arduino_DataBus* bus = new Arduino_ESP32QSPI(TFT_CS, TFT_SCK, TFT_D0, TFT_D1, TFT_D2, TFT_D3);
+    Arduino_GFX* g = new Arduino_NV3041A(bus, TFT_RST, TFT_ROTATION, TFT_IPS);
+    tft = g;
 #elif 1
     /* Reset is not implemented in the panel */
     if(TFT_RST != GFX_NOT_DEFINED) {
@@ -299,6 +303,8 @@ const char* ArduinoGfx::get_tft_model()
     return "R61529";
 #elif defined(RM68140_DRIVER)
     return "RM68140";
+#elif defined(NV3041A_DRIVER)
+    return "NV3041A";
 #else
     return "Other";
 #endif
@@ -336,6 +342,8 @@ uint32_t ArduinoGfx::get_tft_driver()
     return 0x61529;
 #elif defined(RM68140_DRIVER)
     return 0x68140;
+#elif defined(NV3041A_DRIVER)
+    return 0x3041A;
 #else
     return 0x0;
 #endif

--- a/src/hasp_gui.cpp
+++ b/src/hasp_gui.cpp
@@ -341,7 +341,7 @@ void guiSetup()
 #endif
     gui_hide_pointer(false);
     if(mouse_indev != NULL) {
-        lv_indev_set_cursor(mouse_indev, cursor); /*Connect the image  object to the driver*/
+        lv_indev_set_cursor(mouse_indev, cursor); /*Connect the image object to the driver*/
     }
 
 #if HASP_TARGET_ARDUINO

--- a/user_setups/esp32s3/guition-jc4827w543.ini
+++ b/user_setups/esp32s3/guition-jc4827w543.ini
@@ -1,0 +1,60 @@
+;***************************************************;
+;    Guition ESP32-S3 TFT 4.3"                      ;
+;          - Custom esp32-s3 board                  ;
+;          - nv3041a 480x272                        ;
+;          - gt911 touch controller                 ;
+;***************************************************;
+
+[guition-esp32-s3-tft]
+extends = arduino_esp32s3_v2
+board = esp32-s3-devkitc-1
+board_build.arduino.memory_type = qio_opi
+
+build_flags =
+    ${arduino_esp32s3_v2.build_flags}
+    ${esp32s3.ps_ram}
+    ;-D HASP_MODEL="Guition 4.3\""
+
+;region -- ArduinoGFX build options ------------------------
+    -D HASP_USE_ARDUINOGFX
+    -D NV3041A_DRIVER
+    -D BACKLIGHT_FREQUENCY=50
+ ;endregion
+
+lib_deps =
+    ${arduino_esp32s3_v2.lib_deps}
+    ${arduinogfx.lib_deps}
+    ${goodix.lib_deps}
+
+
+[guition-tft-common-pins]
+build_flags =
+    -D TFT_BCKL=1
+    -D TFT_CS=45
+    -D TFT_SCK=47
+    -D TFT_D0=21
+    -D TFT_D1=48
+    -D TFT_D2=40
+    -D TFT_D3=39
+    -D TFT_RST=GFX_NOT_DEFINED
+    -D TFT_ROTATION=0
+    -D TFT_IPS=true
+    -D TFT_WIDTH=480
+    -D TFT_HEIGHT=272
+
+[guition-jc4827w543]
+extends = guition-esp32-s3-tft
+debug_tool = esp-builtin
+debug_build_flags = -Os # optimize for size
+build_flags =
+    -D HASP_MODEL="Guition ESP32-S3 JC4827W543"
+    ${guition-esp32-s3-tft.build_flags}
+    ${guition-tft-common-pins.build_flags}
+    ; Touch Settings
+    -D TOUCH_DRIVER=0x0911
+    -D TOUCH_SCL=4
+    -D TOUCH_SDA=8
+    -D TOUCH_IRQ=-1
+    -D TOUCH_RST=38
+    -D I2C_TOUCH_FREQUENCY=0
+    -D I2C_TOUCH_ADDRESS=0x5D


### PR DESCRIPTION
Resolves #713.

An upgrade of `Arduino_GFX` was required to get this working. I know that v1.4.6 works as well, but I bumped it up to the newest available version. Are changes necessary to `src/drv/tft/Arduino_PCA9535SWSPI.*` for this change to land (per the comment in `platformio.ini`)?