### PR TITLE
Missing the FILE_SIZE_DIVIDER for gigabits

### DIFF
--- a/src/hasp/hasp_parser.cpp
+++ b/src/hasp/hasp_parser.cpp
@@ -212,6 +212,7 @@ int Parser::format_bytes(size_t filesize, char* buf, size_t len)
         return snprintf_P(buf, len, PSTR("%d" D_DECIMAL_POINT "%02d " D_FILE_SIZE_MEGABYTES), filesize / 100,
                           filesize % 100);
 
+    filesize = filesize / D_FILE_SIZE_DIVIDER; // multiply by 100 for 2 decimal place
     return snprintf_P(buf, len, PSTR("%d" D_DECIMAL_POINT "%02d " D_FILE_SIZE_GIGABYTES), filesize / 100,
                       filesize % 100);
 }


### PR DESCRIPTION
Started using the format_bytes function with some real big numbers. Noted that the numbers were not being converted from MB to GB before being printed.