### PR TITLE
Using size_t limits max number to 2^32. 

### DIFF
--- a/src/hasp/hasp_parser.cpp
+++ b/src/hasp/hasp_parser.cpp
@@ -211,7 +211,7 @@ int Parser::format_bytes(uint64_t filesize, char* buf, size_t len)
 
     filesize /= D_FILE_SIZE_DIVIDER;
     tmp = (uint32_t) filesize;
-    if(filesize < D_FILE_SIZE_DIVIDER * D_FILE_SIZE_DIVIDER * 100)
+    if(filesize < D_FILE_SIZE_DIVIDER * 100)
         return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_MEGABYTES), tmp / 100,
                           tmp % 100);
 

--- a/src/hasp/hasp_parser.cpp
+++ b/src/hasp/hasp_parser.cpp
@@ -199,22 +199,24 @@ bool Parser::is_only_digits(const char* s)
 
 int Parser::format_bytes(uint64_t filesize, char* buf, size_t len)
 {
+    filesize *= 100; // Warning - If filesize up in the Zi range (2^60), we will overflow.
     uint32_t tmp = (uint32_t) filesize; // cast to unsigned int here to saye ugly casts in next line
     if(filesize < D_FILE_SIZE_DIVIDER) return snprintf_P(buf, len, PSTR("%u " D_FILE_SIZE_BYTES), tmp);
 
-    filesize = filesize / (D_FILE_SIZE_DIVIDER/100); // multiply by 100 for 2 decimal place
+    filesize /= D_FILE_SIZE_DIVIDER;
     tmp = (uint32_t) filesize;
     if(filesize < D_FILE_SIZE_DIVIDER * 100)
         return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_KILOBYTES), tmp / 100,
                           tmp % 100);
 
-    filesize = filesize / D_FILE_SIZE_DIVIDER;
+    filesize /= D_FILE_SIZE_DIVIDER;
     tmp = (uint32_t) filesize;
-    if(filesize < D_FILE_SIZE_DIVIDER * 100)
+    if(filesize < D_FILE_SIZE_DIVIDER * D_FILE_SIZE_DIVIDER * 100)
         return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_MEGABYTES), tmp / 100,
                           tmp % 100);
 
-    tmp = (uint32_t) (filesize / D_FILE_SIZE_DIVIDER);
+    filesize /= D_FILE_SIZE_DIVIDER;
+    tmp = (uint32_t) filesize;
     return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_GIGABYTES), tmp / 100,
                           tmp % 100);
 }

--- a/src/hasp/hasp_parser.cpp
+++ b/src/hasp/hasp_parser.cpp
@@ -199,7 +199,7 @@ bool Parser::is_only_digits(const char* s)
 
 int Parser::format_bytes(uint64_t filesize, char* buf, size_t len)
 {
-    filesize *= 102400; // Warning - If filesize up in the Ei range (2^60), we will overflow.
+    filesize *= 100; // Warning - If filesize up in the Ei range (2^60), we will overflow.
     uint32_t tmp = (uint32_t) filesize; // cast to unsigned int here to saye ugly casts in next line
     if(filesize < D_FILE_SIZE_DIVIDER) return snprintf_P(buf, len, PSTR("%u " D_FILE_SIZE_BYTES), tmp);
 

--- a/src/hasp/hasp_parser.cpp
+++ b/src/hasp/hasp_parser.cpp
@@ -197,24 +197,26 @@ bool Parser::is_only_digits(const char* s)
     return strlen(s) == digits;
 }
 
-int Parser::format_bytes(size_t filesize, char* buf, size_t len)
+int Parser::format_bytes(uint64_t filesize, char* buf, size_t len)
 {
-    if(filesize < D_FILE_SIZE_DIVIDER) return snprintf_P(buf, len, PSTR("%d " D_FILE_SIZE_BYTES), filesize);
-    filesize = filesize * 100;
+    uint32_t tmp = (uint32_t) filesize; // cast to unsigned int here to saye ugly casts in next line
+    if(filesize < D_FILE_SIZE_DIVIDER) return snprintf_P(buf, len, PSTR("%u " D_FILE_SIZE_BYTES), tmp);
 
-    filesize = filesize / D_FILE_SIZE_DIVIDER; // multiply by 100 for 2 decimal place
+    filesize = filesize / (D_FILE_SIZE_DIVIDER/100); // multiply by 100 for 2 decimal place
+    tmp = (uint32_t) filesize;
     if(filesize < D_FILE_SIZE_DIVIDER * 100)
-        return snprintf_P(buf, len, PSTR("%d" D_DECIMAL_POINT "%02d " D_FILE_SIZE_KILOBYTES), filesize / 100,
-                          filesize % 100);
+        return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_KILOBYTES), tmp / 100,
+                          tmp % 100);
 
-    filesize = filesize / D_FILE_SIZE_DIVIDER; // multiply by 100 for 2 decimal place
+    filesize = filesize / D_FILE_SIZE_DIVIDER;
+    tmp = (uint32_t) filesize;
     if(filesize < D_FILE_SIZE_DIVIDER * 100)
-        return snprintf_P(buf, len, PSTR("%d" D_DECIMAL_POINT "%02d " D_FILE_SIZE_MEGABYTES), filesize / 100,
-                          filesize % 100);
+        return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_MEGABYTES), tmp / 100,
+                          tmp % 100);
 
-    filesize = filesize / D_FILE_SIZE_DIVIDER; // multiply by 100 for 2 decimal place
-    return snprintf_P(buf, len, PSTR("%d" D_DECIMAL_POINT "%02d " D_FILE_SIZE_GIGABYTES), filesize / 100,
-                      filesize % 100);
+    tmp = (uint32_t) (filesize / D_FILE_SIZE_DIVIDER);
+    return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_GIGABYTES), tmp / 100,
+                          tmp % 100);
 }
 
 uint8_t Parser::get_action_id(const char* action)

--- a/src/hasp/hasp_parser.cpp
+++ b/src/hasp/hasp_parser.cpp
@@ -199,7 +199,7 @@ bool Parser::is_only_digits(const char* s)
 
 int Parser::format_bytes(uint64_t filesize, char* buf, size_t len)
 {
-    filesize *= 100; // Warning - If filesize up in the Zi range (2^60), we will overflow.
+    filesize *= 100; // Warning - If filesize up in the Ei range (2^60), we will overflow.
     uint32_t tmp = (uint32_t) filesize; // cast to unsigned int here to saye ugly casts in next line
     if(filesize < D_FILE_SIZE_DIVIDER) return snprintf_P(buf, len, PSTR("%u " D_FILE_SIZE_BYTES), tmp);
 

--- a/src/hasp/hasp_parser.cpp
+++ b/src/hasp/hasp_parser.cpp
@@ -199,16 +199,18 @@ bool Parser::is_only_digits(const char* s)
 
 int Parser::format_bytes(uint64_t filesize, char* buf, size_t len)
 {
-    filesize *= 100; // Warning - If filesize up in the Ei range (2^60), we will overflow.
+    filesize *= 102400; // Warning - If filesize up in the Ei range (2^60), we will overflow.
     uint32_t tmp = (uint32_t) filesize; // cast to unsigned int here to saye ugly casts in next line
     if(filesize < D_FILE_SIZE_DIVIDER) return snprintf_P(buf, len, PSTR("%u " D_FILE_SIZE_BYTES), tmp);
 
-    const char* suffix[] = {D_FILE_SIZE_KILOBYTES, D_FILE_SIZE_MEGABYTES, D_FILE_SIZE_GIGABYTES};
+    const char* suffix[] = {D_FILE_SIZE_KILOBYTES, D_FILE_SIZE_MEGABYTES, D_FILE_SIZE_GIGABYTES, "oops"};
+    #define UNKNOWN_SUFFIX 2
     int n = -1;
-    while (filesize > D_FILE_SIZE_DIVIDER * 100) {
+    while (filesize > D_FILE_SIZE_DIVIDER * 100 && n < UNKNOWN_SUFFIX) {
         n += 1;
         filesize /= D_FILE_SIZE_DIVIDER;
     }
+
     tmp = (uint32_t) filesize;
     return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u %s"), tmp / 100, tmp % 100,  suffix[n]);
 }

--- a/src/hasp/hasp_parser.cpp
+++ b/src/hasp/hasp_parser.cpp
@@ -203,22 +203,14 @@ int Parser::format_bytes(uint64_t filesize, char* buf, size_t len)
     uint32_t tmp = (uint32_t) filesize; // cast to unsigned int here to saye ugly casts in next line
     if(filesize < D_FILE_SIZE_DIVIDER) return snprintf_P(buf, len, PSTR("%u " D_FILE_SIZE_BYTES), tmp);
 
-    filesize /= D_FILE_SIZE_DIVIDER;
+    const char* suffix[] = {D_FILE_SIZE_KILOBYTES, D_FILE_SIZE_MEGABYTES, D_FILE_SIZE_GIGABYTES};
+    int n = -1;
+    while (filesize > D_FILE_SIZE_DIVIDER * 100) {
+        n += 1;
+        filesize /= D_FILE_SIZE_DIVIDER;
+    }
     tmp = (uint32_t) filesize;
-    if(filesize < D_FILE_SIZE_DIVIDER * 100)
-        return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_KILOBYTES), tmp / 100,
-                          tmp % 100);
-
-    filesize /= D_FILE_SIZE_DIVIDER;
-    tmp = (uint32_t) filesize;
-    if(filesize < D_FILE_SIZE_DIVIDER * 100)
-        return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_MEGABYTES), tmp / 100,
-                          tmp % 100);
-
-    filesize /= D_FILE_SIZE_DIVIDER;
-    tmp = (uint32_t) filesize;
-    return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u " D_FILE_SIZE_GIGABYTES), tmp / 100,
-                          tmp % 100);
+    return snprintf_P(buf, len, PSTR("%u" D_DECIMAL_POINT "%02u %s"), tmp / 100, tmp % 100,  suffix[n]);
 }
 
 uint8_t Parser::get_action_id(const char* action)

--- a/src/hasp/hasp_parser.h
+++ b/src/hasp/hasp_parser.h
@@ -19,7 +19,7 @@ class Parser {
     static bool is_true(const char* s);
     static bool is_true(JsonVariant json);
     static bool is_only_digits(const char* s);
-    static int format_bytes(size_t filesize, char* buf, size_t len);
+    static int format_bytes(uint64_t filesize, char* buf, size_t len);
 };
 
 #ifndef ARDUINO


### PR DESCRIPTION
When dealing with SD cards we could be asked to print a uint64 (for example, from SD.totalGytes()).
This attempt to handle the very large numbers that might be expected from an SD card.

Yes, there is a bit of ugliness from recasting to a uint32 before calling the snprintf function, but this avoids implicit casts where data could be truncated. 