### PR TITLE
Add support for sunton esp32-2432s024{r,c}

### DIFF
--- a/src/drv/tft/tft_driver_lovyangfx.cpp
+++ b/src/drv/tft/tft_driver_lovyangfx.cpp
@@ -381,6 +381,32 @@ lgfx::ITouch* _init_touch(Preferences* preferences)
     }
 #endif
 
+#if TOUCH_DRIVER == 0x0820
+
+    { // タッチスクリーン制御の設定を行います。（必要なければ削除）
+        auto touch = new lgfx::Touch_FT5x06();
+        auto cfg   = touch->config();
+
+        cfg.x_min      = 0;              // The minimum X value obtained from the touchscreen (raw value).
+        cfg.x_max      = TFT_WIDTH - 1;  // The maximum X value obtained from the touchscreen (raw value).
+        cfg.y_min      = 0;              // The minimum Y value obtained from the touchscreen (raw value).
+        cfg.y_max      = TFT_HEIGHT - 1; // The maximum Y value obtained from the touchscreen (raw value).
+        cfg.bus_shared = true;           // If using a common bus with the screen, set it to true.
+        cfg.offset_rotation = TOUCH_OFFSET_ROTATION; // Adjustment when the display orientation does not match the touch orientation. Set in values from 0 to 7.
+
+        // I2C接続の場合
+        cfg.i2c_port = I2C_TOUCH_PORT;      // 使用するI2Cを選択 (0 or 1)
+        cfg.i2c_addr = I2C_TOUCH_ADDRESS;   // I2Cデバイスアドレス番号
+        cfg.pin_sda  = TOUCH_SDA;           // SDAが接続されているピン番号
+        cfg.pin_scl  = TOUCH_SCL;           // SCLが接続されているピン番号
+        cfg.pin_int  = TOUCH_IRQ;           // INTが接続されているピン番号
+        cfg.freq     = I2C_TOUCH_FREQUENCY; // I2Cクロックを設定
+
+        touch->config(cfg);
+        return touch;
+    }
+#endif
+
 #if TOUCH_DRIVER == 0x6336
     {
         auto touch = new lgfx::Touch_FT5x06();

--- a/user_setups/esp32s3/sunton-esp32-2432s024.ini
+++ b/user_setups/esp32s3/sunton-esp32-2432s024.ini
@@ -1,0 +1,101 @@
+;***************************************************;
+;       Sunton ESP32-WROOM custom dev board with    ;
+;               - ILI9341 TFT SPI 4-WIRE             ;
+;               - XPT2046 or CST820 touch controller ;
+;***************************************************;
+
+[sunton-esp32-2432s024]
+extends = arduino_esp32_v2
+board = esp32dev
+
+build_flags =
+    ${arduino_esp32_v2.build_flags}
+    ${esp32.no_ps_ram}
+
+;region -- TFT_eSPI build options ------------------------
+    ${esp32.hspi}        ; Use HSPI hardware SPI bus
+    -D ILI9341_DRIVER=1
+    -D TFT_ROTATION=0 ; 0=0, 1=90, 2=180 or 3=270 degree
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=320
+    -D TFT_CS=15      ;// Chip select control pin
+    -D TFT_DC=2       ;// Data Command control pin
+    -D TFT_RST=-1     ;// Reset pin (could connect to RST pin)
+    -D TFT_BCKL=27    ;None, configurable via web UI (e.g. 2 for D4)
+    -D SUPPORT_TRANSACTIONS
+    -D SPI_FREQUENCY=65000000
+    -D SPI_READ_FREQUENCY=20000000
+;endregion
+
+; -- Debugging options -----------------------------
+;   -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+
+
+[env:esp32-2432s024r_4MB]
+extends = sunton-esp32-2432s024, flash_4mb
+build_flags =
+    ${sunton-esp32-2432s024.build_flags}
+    -D USER_SETUP_LOADED=1
+    -D TOUCH_CS=33
+    -D TOUCH_DRIVER=0x2046 ; XPT2606 Resistive touch panel driver
+    -D HASP_USE_LGFX_TOUCH=1
+    -D TOUCH_SDA=-1
+    -D TOUCH_SCL=-1
+    -D TOUCH_IRQ=-1
+    -D I2C_TOUCH_PORT=0
+    -D I2C_TOUCH_ADDRESS=0
+    -D I2C_TOUCH_FREQUENCY=0
+    -D SPI_TOUCH_FREQUENCY=2500000
+
+lib_deps =
+    ${sunton-esp32-2432s024.lib_deps}
+    ${tft_espi.lib_deps}
+    ;${lovyangfx.lib_deps}
+    
+
+[env:esp32-2432s024c_4MB]
+upload_port = /dev/ttyUSB0
+extends = sunton-esp32-2432s024, flash_4mb
+board = esp32dev
+
+build_flags =
+    ${sunton-esp32-2432s024.build_flags}
+    ${esp32.no_ps_ram}
+
+;region -- TFT_eSPI build options ------------------------
+    ${esp32.hspi}        ; Use HSPI hardware SPI bus
+    ;-D USER_SETUP_LOADED=1
+    -D LGFX_USE_V1=1
+    -D ILI9341_DRIVER=1
+    -D TOUCH_DRIVER=0x0820 ; CST820 Capacitive I2C touch panel driver
+    -D HASP_USE_LGFX_TOUCH=1
+    -D TFT_ROTATION=2 ; 0=0, 1=90, 2=180 or 3=270 degree
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=320
+    -D TFT_CS=15      ;// Chip select control pin
+    -D TFT_DC=2       ;// Data Command control pin
+    -D TFT_RST=-1     ;// Reset pin (could connect to RST pin)
+    -D TFT_BCKL=27    ;None, configurable via web UI (e.g. 2 for D4)
+    -D SUPPORT_TRANSACTIONS    
+    -D TOUCH_SDA=33
+    -D TOUCH_SCL=32
+    -D TOUCH_IRQ=21
+    -D TOUCH_OFFSET_ROTATION=2  ;touch rotation
+    ;-D TOUCH_IRQ=-1
+    -D TOUCH_RST=25
+    -D I2C_TOUCH_FREQUENCY=400000
+    -D I2C_TOUCH_PORT=1
+    -D I2C_TOUCH_ADDRESS=0x15 ; or 0x14
+    -D SPI_FREQUENCY=65000000
+    -D SPI_TOUCH_FREQUENCY=2500000
+    -D SPI_READ_FREQUENCY=20000000
+;endregion
+
+; -- Debugging options -----------------------------
+;   -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+
+lib_deps =
+    ${sunton-esp32-2432s024.lib_deps}
+    ;${tft_espi.lib_deps}
+    ${lovyangfx.lib_deps}
+    ;${goodix.lib_deps}


### PR DESCRIPTION
This adds support for the Sunton esp32-2432s024{r,c} displays.

This is based on the code contributed by @elik754i in #555 . A few caveats:

- I do not own an esp32-2432s024r, only an esp32-2432s024c. So I cannot vouch that the "r" variant works. I have tested the "c" variant and it works.
- It looks like @elik745i added the support for the `CST820` touch controller to an older version of the `tft_driver_lovyangfx.cpp` file than the version in the openHASP repo. I transplanted the necessary changes into the file in this repo. I do not know where they got that code from and I cannot read the chinese comments, but it seems to work.
- I am not sure about the naming. I think I read somewhere that the esp32 on these boards is an 'ESP32 S3', so I put the user-config into the `esp32s3` folder, but I'm not sure what an 's2' or 's3' esp32 is or whether this is correct in this case.
- I'm not sure about the naming of the build environments. Some of the Sunton boards' environments seem to be named `sunton-<whatever>`, others just `esp32-<whatever>`. I opted for the latter, but feel free to change that.