### PR TITLE
Was a mistake to hide TFT_BCKL gpio pin from the user. On some boards…

### DIFF
--- a/src/drv/tft/tft_driver_arduinogfx.cpp
+++ b/src/drv/tft/tft_driver_arduinogfx.cpp
@@ -296,9 +296,6 @@ bool ArduinoGfx::is_driver_pin(uint8_t pin)
 #ifdef TFT_HSYNC
        || (pin == TFT_HSYNC)
 #endif
-#ifdef TFT_BCKL
-       || (pin == TFT_BCKL)
-#endif
 #ifdef TFT_RST
        || (pin == TFT_RST)
 #endif


### PR DESCRIPTION
…, it

can be reassigned by the user (on others, it is baked in to the hardware).

Closes issue #751