### PR TITLE
Hide TFT-G5 & USB GPIO pins in web page

### DIFF
--- a/src/drv/tft/tft_driver_arduinogfx.cpp
+++ b/src/drv/tft/tft_driver_arduinogfx.cpp
@@ -335,6 +335,9 @@ bool ArduinoGfx::is_driver_pin(uint8_t pin)
 #ifdef TFT_G4
        || (pin == TFT_G4)
 #endif
+#ifdef TFT_G5
+       || (pin == TFT_G5)
+#endif
 #ifdef TFT_B0
        || (pin == TFT_B0)
 #endif
@@ -361,6 +364,12 @@ bool ArduinoGfx::is_driver_pin(uint8_t pin)
 #endif
 #ifdef TOUCH_IRQ
        || (pin == TOUCH_IRQ)
+#endif
+#ifdef USB_TXD
+       || (pin == USB_TXD)
+#endif
+#ifdef USB_RXD
+       || (pin == USB_RXD)
 #endif
     ) {
         return true;

--- a/user_setups/esp32s3/esp32-s3-4848S040.ini
+++ b/user_setups/esp32s3/esp32-s3-4848S040.ini
@@ -76,6 +76,10 @@ build_flags =
     -D I2C_TOUCH_FREQUENCY=400000
     -D I2C_TOUCH_ADDRESS=0x5D ; or 0x14
     -D I2C_TOUCH_PORT=1
+    ; USB GPIO - Only need to define these so that the pins do not
+    ; show up in the list of available GPIO
+    -D USB_TXD=43
+    -D USB_RXD=44
 ;endregion
 
 lib_deps =


### PR DESCRIPTION
Forgot to include the TFT_G5 GPIO pin in the is_driver_pin() list.
Whilst at it, include the USB TX/RX pins for the Guition ESP32-S3 4848S040 board. These two pins are wired to a CH340C chip, so not available for other uses.