### PR TITLE
Move USB_TXD/RXD to is_system_pin()

### DIFF
--- a/src/drv/tft/tft_driver_arduinogfx.cpp
+++ b/src/drv/tft/tft_driver_arduinogfx.cpp
@@ -365,12 +365,6 @@ bool ArduinoGfx::is_driver_pin(uint8_t pin)
 #ifdef TOUCH_IRQ
        || (pin == TOUCH_IRQ)
 #endif
-#ifdef USB_TXD
-       || (pin == USB_TXD)
-#endif
-#ifdef USB_RXD
-       || (pin == USB_RXD)
-#endif
     ) {
         return true;
     }


### PR DESCRIPTION
Realised there is a is_system_pi() function - The USB TX/RX pins are better off there rather than hijacking the is_driver_pin() function.