### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools",
+				"platformio.platformio-ide"
+			]
+		}
+	},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
+	// Allow uploading to device
+	"mounts": ["type=bind,source=/dev/bus/usb,target=/dev/bus/usb"],
+	"runArgs": ["--privileged"]
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/platformio_override-template.ini
+++ b/platformio_override-template.ini
@@ -22,7 +22,7 @@ build_flags =
 
 ;region -- Default Build Environments : Used when Build All ---
 extra_default_envs =
-    ; Uncomment specific environments or create extra:
+    ; Uncomment specific environments or create extra (copy names from square brackets in user_setups/*/*.ini):
     ; az-touch-mod-esp32_ili9341_4MB
     ; az-touch-mod-esp32_ili9341_8MB
     ; d1-mini-esp32_ili9341
@@ -64,6 +64,9 @@ extra_default_envs =
     ; makerfabs-tft35-cap_4MB
     ; makerfabs-tft-s2_ili9488
     ; nodemcu32s-raspi
+    ; panlee-zw3d95ce01s-ar-4848_16MB
+    ; panlee-zw3d95ce01s-tr-4848_16MB
+    ; panlee-zw3d95ce01s-ur-4848_16MB
     ; s2-mini-esp32s2_ili9341
     ; ttgo_esp32_poe-ili9341
     ; lilygo-lily-pi_ili9481


### PR DESCRIPTION
Hi,
thanks for the project, it seems the only one currently able to run on my panlee device.
I struggled to install all the dependencies and make platformio work on my fedora laptop, so I ended up managing to do it with the devcontainers. Here's my contribution back to the community, for once :)

Notes:
- I kept all the default comments, but can strip them out if a cleaner file is preferred
- It automatically created the dependabot, again, can remove it if not needed, but I preferred to ask rather than just omit it
- Added the panlee devices (and instruction on where to find more) in the template, as I didn't understand I had to add them there. In hindsight this was more obvious, but it's my first time messing with platformio, and maybe I'm not the only one