### PR TITLE
First draft at noise reduction for the GT911 touch driver.

### DIFF
--- a/src/drv/touch/touch_driver_gt911.cpp
+++ b/src/drv/touch/touch_driver_gt911.cpp
@@ -92,9 +92,42 @@ IRAM_ATTR bool TouchGt911::read(lv_indev_drv_t* indev_driver, lv_indev_data_t* d
     return false;
 }
 
+#include "hexdump.h"
+#include <driver/timer.h>
+#include <soc/timer_group_struct.h>
+#include <soc/timer_group_reg.h>
+static void setup_noise_reduction(uint8_t nr_level)
+{
+    uint8_t len = 0x8100 - GT_REG_CFG;
+    uint8_t cfg[len];
+    GTInfo* info;
+
+    memset(cfg, 0, len);
+/*    This is the only way to read the entire config space
+    Need to do a split read as the WDT will bite for reads
+    of more than 128 bytes (give or take).
+*/
+    touch.read(GT_REG_CFG, cfg, 100);
+    touch.read(GT_REG_CFG+100, cfg+100, len-100);
+
+    // Check noise_reduction is within limits
+    if (nr_level < 0 || nr_level > 15) goto end;
+
+    cfg[11] = nr_level;
+    cfg[len - 1] = touch.calcChecksum(cfg, len - 1);
+
+    uint8_t err = touch.write(GT_REG_CFG, cfg, len);
+    if (err != 0) goto end;
+    err = touch.write(0x8100, 1);
+
+end:
+    LOG_ERROR(TAG_DRVR, "GT911 Failed to write noise reduction byte");
+}
+
 void TouchGt911::init(int w, int h)
 {
     Wire.begin(TOUCH_SDA, TOUCH_SCL, (uint32_t)I2C_TOUCH_FREQUENCY);
+
     touch.setHandler(GT911_setXY);
     GTInfo* info;
 
@@ -102,7 +135,7 @@ void TouchGt911::init(int w, int h)
         info = touch.readInfo();
         if(info->xResolution > 0 && info->yResolution > 0) goto found;
     }
-    
+
 #if TOUCH_IRQ == -1
     // Probe both addresses if IRQ is not connected
     for(uint8_t i = 0; i < 4; i++)
@@ -119,6 +152,8 @@ found:
     } else {
         LOG_WARNING(TAG_DRVR, "GT911 %s", D_SERVICE_START_FAILED);
     }
+
+    setup_noise_reduction((uint8_t) h);
 
     Wire.begin(TOUCH_SDA, TOUCH_SCL, (uint32_t)I2C_TOUCH_FREQUENCY);
     touch_scan(Wire); // The address could change during begin, so scan afterwards

--- a/src/hasp_config.h
+++ b/src/hasp_config.h
@@ -80,6 +80,7 @@ const char FP_CONFIG_VPN_IP[] PROGMEM          = "vpnip";
 const char FP_CONFIG_PRIVATE_KEY[] PROGMEM     = "privkey";
 const char FP_CONFIG_PUBLIC_KEY[] PROGMEM      = "pubkey";
 const char FP_GUI_ROTATION[] PROGMEM           = "rotate";
+const char FP_GUI_NOISE_REDUCTION[] PROGMEM    = "noise_reduction";
 const char FP_GUI_INVERT[] PROGMEM             = "invert";
 const char FP_GUI_TICKPERIOD[] PROGMEM         = "tick";
 const char FP_GUI_IDLEPERIOD1[] PROGMEM        = "idle1";

--- a/src/hasp_gui.cpp
+++ b/src/hasp_gui.cpp
@@ -46,6 +46,7 @@ gui_conf_t gui_settings = {.show_pointer   = false,
                            .backlight_pin  = TFT_BCKL,
                            .rotation       = TFT_ROTATION,
                            .invert_display = INVERT_COLORS,
+                           .noise_reduction = 5,
                            .cal_data       = {0, 65535, 0, 65535, 0}};
 lv_obj_t* cursor;
 
@@ -346,7 +347,8 @@ void guiSetup()
 
 #if HASP_TARGET_ARDUINO
     // drv_touch_init(gui_settings.rotation); // Touch driver
-    haspTouch.init(tft_width, tft_height);
+    // hijack tft_height to pass noise_reduction to the GT911 driver
+    haspTouch.init(tft_width, gui_settings.noise_reduction);
     haspTouch.set_calibration(gui_settings.cal_data);
     haspTouch.set_rotation(gui_settings.rotation);
 #endif
@@ -488,6 +490,9 @@ bool guiGetConfig(const JsonObject& settings)
     if(gui_settings.rotation != settings[FPSTR(FP_GUI_ROTATION)].as<uint8_t>()) changed = true;
     settings[FPSTR(FP_GUI_ROTATION)] = gui_settings.rotation;
 
+    if(gui_settings.noise_reduction != settings[FPSTR(FP_GUI_NOISE_REDUCTION)].as<uint8_t>()) changed = true;
+    settings[FPSTR(FP_GUI_NOISE_REDUCTION)] = gui_settings.noise_reduction;
+
     if(gui_settings.show_pointer != settings[FPSTR(FP_GUI_POINTER)].as<bool>()) changed = true;
     settings[FPSTR(FP_GUI_POINTER)] = (uint8_t)gui_settings.show_pointer;
 
@@ -562,6 +567,7 @@ bool guiSetConfig(const JsonObject& settings)
     changed |= configSet(guiSleepTime1, settings[FPSTR(FP_GUI_IDLEPERIOD1)], F("guiSleepTime1"));
     changed |= configSet(guiSleepTime2, settings[FPSTR(FP_GUI_IDLEPERIOD2)], F("guiSleepTime2"));
     changed |= configSet(gui_settings.rotation, settings[FPSTR(FP_GUI_ROTATION)], F("gui_settings.rotation"));
+    changed |= configSet(gui_settings.noise_reduction, settings[FPSTR(FP_GUI_NOISE_REDUCTION)], F("gui_settings.noise_reduction"));
     changed |= configSet(gui_settings.invert_display, settings[FPSTR(FP_GUI_INVERT)], F("guiInvertDisplay"));
 
     hasp_set_sleep_time(guiSleepTime1, guiSleepTime2);

--- a/src/hasp_gui.h
+++ b/src/hasp_gui.h
@@ -33,6 +33,7 @@ struct gui_conf_t
     int8_t backlight_pin;
     uint8_t rotation;
     uint8_t invert_display;
+    uint8_t noise_reduction;
 #if defined(USER_SETUP_LOADED)
     uint16_t cal_data[5];
 #else

--- a/src/sys/svc/hasp_http.cpp
+++ b/src/sys/svc/hasp_http.cpp
@@ -1562,6 +1562,10 @@ static void http_handle_gui()
 </select></div>
 </div>
 <div class="row">
+<div class="col-25"><label for="noise_reduction">Noise Reduction</label></div>
+<div class="col-75"><input type="number" id="noise_reduction" min="0" max="15" v-model="config.gui.noise_reduction"></div>
+</div>
+<div class="row">
 <div class="col-25"></div>
 <div class="col-75"><input type="checkbox" id="invert" @vue:mounted="config.gui.invert = !!config.gui.invert" v-model="config.gui.invert">
 <label for="invert">Invert Colors</label></div>

--- a/src/sys/svc/hasp_http_async.cpp
+++ b/src/sys/svc/hasp_http_async.cpp
@@ -1298,6 +1298,11 @@ void webHandleGuiConfig(AsyncWebServerRequest* request)
         httpMessage += getOption(5, F("270 degrees - mirrored"), rotation == 5);
         httpMessage += F("</select></p>");
 
+        httpMessage += F("<p><b>Noise Reduction</b> <input id='noise_reduction' required "
+                         "name='noise_reduction' type='number' min='0' max='15' value='");
+        int8_t noise_reduction = settings[FPSTR(FP_GUI_NOISE_REDUCTION)].as<int8_t>();
+        httpMessage += F("'></p>");
+
         httpMessage += F("<p><input id='inv' name='inv' type='checkbox' ");
         if(settings[FPSTR(FP_GUI_INVERT)].as<bool>()) httpMessage += F(" checked");
         httpMessage += F("><b>Invert Colors</b>");


### PR DESCRIPTION
This allows the user to decrease sensitivity of the touch panel in order to eliminate phantom touch events due to electromagnetic interference in response to issue #706 
This may be possible to extend to other touch screens if the function is supported.