### PR TITLE
Fix support for Adafruit HUZZAH32 V2 ESP32 Featherwing 3.5 V2

### DIFF
--- a/src/sys/gpio/hasp_gpio.cpp
+++ b/src/sys/gpio/hasp_gpio.cpp
@@ -123,7 +123,7 @@ static void gpio_event_handler(AceButton* button, uint8_t eventType, uint8_t but
     bool state = false;
     switch(eventType) {
         case AceButton::kEventPressed:
-            if(gpioConfig[btnid].type != hasp_gpio_type_t::BUTTON) {
+            if(gpioConfig[btnid].type != hasp_gpio_type_t::BUTTON_TYPE) {
                 eventid = HASP_EVENT_ON;
             } else {
                 eventid = HASP_EVENT_DOWN;
@@ -146,7 +146,7 @@ static void gpio_event_handler(AceButton* button, uint8_t eventType, uint8_t but
         //     state = true; // do not repeat DOWN + LONG + HOLD
         //     break;
         case AceButton::kEventReleased:
-            if(gpioConfig[btnid].type != hasp_gpio_type_t::BUTTON) {
+            if(gpioConfig[btnid].type != hasp_gpio_type_t::BUTTON_TYPE) {
                 eventid = HASP_EVENT_OFF;
             } else {
                 eventid = HASP_EVENT_RELEASE;
@@ -253,7 +253,7 @@ static void gpio_setup_pin(uint8_t index)
             pinMode(gpio->pin, input_mode);
             gpio->max = 0;
             break;
-        case hasp_gpio_type_t::BUTTON:
+        case hasp_gpio_type_t::BUTTON_TYPE:
             if(gpio->btn) delete gpio->btn;
             gpio->btn   = new AceButton(&buttonConfig, gpio->pin, default_state, index);
             gpio->power = gpio->btn->isPressedRaw();
@@ -849,7 +849,7 @@ void gpio_discovery(JsonObject& input, JsonArray& relay, JsonArray& light, JsonA
                 relay.add(gpioConfig[i].pin);
                 break;
                 
-            case BUTTON ... TOUCH:
+            case BUTTON_TYPE ... TOUCH:
                 event.add(gpioConfig[i].pin);
                 break;
 
@@ -861,7 +861,7 @@ void gpio_discovery(JsonObject& input, JsonArray& relay, JsonArray& light, JsonA
                 dimmer.add(gpioConfig[i].pin);
                 break;
 
-            // case BUTTON ... TOUCH:
+            // case BUTTON_TYPE ... TOUCH:
             case SWITCH:
                 strcpy_P(description, PSTR("none"));
                 break;
@@ -955,7 +955,7 @@ void gpio_discovery(JsonObject& input, JsonArray& relay, JsonArray& light, JsonA
         }
 
         if((gpioConfig[i].type >= hasp_gpio_type_t::SWITCH && gpioConfig[i].type <= hasp_gpio_type_t::WINDOW)) {
-            // || (gpioConfig[i].type >= hasp_gpio_type_t::BUTTON && gpioConfig[i].type <= hasp_gpio_type_t::TOUCH)) {
+            // || (gpioConfig[i].type >= hasp_gpio_type_t::BUTTON_TYPE && gpioConfig[i].type <= hasp_gpio_type_t::TOUCH)) {
             JsonArray arr = input[description];
             if(arr.isNull()) arr = input.createNestedArray(description);
             arr.add(gpioConfig[i].pin);

--- a/src/sys/gpio/hasp_gpio.h
+++ b/src/sys/gpio/hasp_gpio.h
@@ -134,7 +134,7 @@ enum hasp_gpio_type_t {
     TAMPER           = 0xBB,
     UPDATE           = 0xBC,
 
-    BUTTON             = 0xF0,
+    BUTTON_TYPE        = 0xF0,
     BUTTON_TOGGLE_UP   = 0xF1,
     BUTTON_TOGGLE_DOWN = 0xF2,
     BUTTON_TOGGLE_BOTH = 0xF3,

--- a/src/sys/svc/hasp_http.cpp
+++ b/src/sys/svc/hasp_http.cpp
@@ -1804,7 +1804,7 @@ static void webHandleGpioConfig()
 
                     switch(conf.type) {
 
-                        case hasp_gpio_type_t::BUTTON:
+                        case hasp_gpio_type_t::BUTTON_TYPE:
                             httpMessage += D_GPIO_BUTTON;
                             break;
                         case hasp_gpio_type_t::SWITCH:
@@ -2049,7 +2049,7 @@ static void webHandleGpioInput()
         httpMessage += F("</select></p>");
 
         httpMessage += F("<p><b>Type</b> <select id='type' name='type'>");
-        httpMessage += getOption(hasp_gpio_type_t::BUTTON, D_GPIO_BUTTON, conf.type);
+        httpMessage += getOption(hasp_gpio_type_t::BUTTON_TYPE, D_GPIO_BUTTON, conf.type);
         httpMessage += getOption(hasp_gpio_type_t::SWITCH, D_GPIO_SWITCH, conf.type);
         httpMessage += getOption(hasp_gpio_type_t::DOOR, "door", conf.type);
         httpMessage += getOption(hasp_gpio_type_t::GARAGE_DOOR, "garage_door", conf.type);

--- a/src/sys/svc/hasp_http_async.cpp
+++ b/src/sys/svc/hasp_http_async.cpp
@@ -1479,7 +1479,7 @@ void webHandleGpioConfig(AsyncWebServerRequest* request)
 
                     switch(conf.type) {
 
-                        case hasp_gpio_type_t::BUTTON:
+                        case hasp_gpio_type_t::BUTTON_TYPE:
                             httpMessage += F(D_GPIO_BUTTON);
                             break;
                         case hasp_gpio_type_t::SWITCH:
@@ -1757,8 +1757,8 @@ void webHandleGpioInput(AsyncWebServerRequest* request)
         bool selected;
         httpMessage += F("<p><b>Type</b> <select id='type' name='type'>");
 
-        selected = (conf.type == hasp_gpio_type_t::BUTTON);
-        httpMessage += getOption(hasp_gpio_type_t::BUTTON, F(D_GPIO_BUTTON), selected);
+        selected = (conf.type == hasp_gpio_type_t::BUTTON_TYPE);
+        httpMessage += getOption(hasp_gpio_type_t::BUTTON_TYPE, F(D_GPIO_BUTTON), selected);
 
         selected = (conf.type == hasp_gpio_type_t::SWITCH);
         httpMessage += getOption(hasp_gpio_type_t::SWITCH, F(D_GPIO_SWITCH), selected);

--- a/user_setups/esp32/huzzah32-v2-featherwing-35-v2.ini
+++ b/user_setups/esp32/huzzah32-v2-featherwing-35-v2.ini
@@ -6,8 +6,8 @@
 ;***************************************************;
 
 [env:huzzah32-v2-featherwing-35-v2]
-extends = arduino_esp32_v2, flash_4mb
-board = featheresp32
+extends = arduino_esp32_v2, flash_8mb
+board = adafruit_feather_esp32_v2
 
 build_flags =
     -D HASP_MODEL="Adafruit HUZZAH32 V2 ESP32 Featherwing 3.5 V2"
@@ -16,13 +16,14 @@ build_flags =
     -D LV_INDEV_DEF_READ_PERIOD=30
 ;region -- TFT_eSPI build options ------------------------
     ${lcd.featherwing-35-v2}
-    -D TFT_MISO=19
-    -D TFT_MOSI=18
-    -D TFT_SCLK=5
-    -D TFT_DC=10
-    -D TFT_CS=9
+    -D TFT_MISO=21 ; GPIO21 / MISO
+    -D TFT_MOSI=19 ; GPIO19 / MOSI
+    -D TFT_SCLK=5 ; GPIO5 / SCK
+    -D TFT_DC=33 ; GPIO33 / D33
+    -D TFT_CS=15 ; GPIO15 / D15
     -D TFT_RST=-1  ; RST
-    -D TFT_BCKL=21 ; Solder the LITE pad to a PWM enabled pin of the ESP, like GPIO 21
+
+    -D TFT_BCKL=37 ; Solder the LITE pad to a PWM enabled pin of the ESP, like GPIO 21
 ;endregion
 
 lib_deps =


### PR DESCRIPTION
* The board of "env:huzzah32-v2-featherwing-35-v2" was changed to adafruit_feather_esp32_v2

  Previously it was pointing to the v1 board. See also:

  V1: https://github.com/platformio/platform-espressif32/blob/develop/boards/featheresp32.json
  V2: https://github.com/platformio/platform-espressif32/blob/develop/boards/adafruit_feather_esp32_v2.json

* Fixed the port numbers
* hasp_gpio_type_t::BUTTON had to be renamed because adafruit_feather_esp32_v2/pins_arduino.h defines a macro named BUTTON.