### PR TITLE
Remove to unsupported HASP_USE_HA

### DIFF
--- a/include/user_config_override-template.h
+++ b/include/user_config_override-template.h
@@ -148,7 +148,6 @@
  **************************************************/
 //#define HASP_USE_MDNS 0                             // Disable MDNS
 //#define HASP_USE_CUSTOM 1                           // Enable compilation of custom code from /src/custom
-//#define HASP_USE_HA                                 // Enable Home Assistant auto-discovery
 //#define HASP_START_CONSOLE 0                        // Disable starting of serial console at boot
 //#define HASP_START_TELNET 0                         // Disable starting of telnet service at boot
 //#define HASP_START_HTTP 0                           // Disable starting of web interface at boot

--- a/src/mqtt/hasp_mqtt_esp.cpp
+++ b/src/mqtt/hasp_mqtt_esp.cpp
@@ -250,14 +250,6 @@ static void mqtt_message_cb(const char* topic, byte* payload, unsigned int lengt
         topic += strlen_P(mqttBroadcastCommandTopic.c_str());                // shorten Broadcast topic
 #endif
 
-#ifdef HASP_USE_HA
-    } else if(topic == strstr_P(topic, PSTR("homeassistant/status"))) { // HA discovery topic
-        if(mqttHAautodiscover && !strcasecmp_P((char*)payload, PSTR("online"))) {
-            mqtt_ha_register_auto_discovery(); // auto-discovery first
-            dispatch_current_state(TAG_MQTT);  // send the data
-        }
-        return;
-#endif
     } else if(topic == strstr(topic, mqttHassLwtTopic.c_str())) { // startsWith mqttGroupCommandTopic
         String state = String((const char*)payload);
         state.toLowerCase();
@@ -375,17 +367,6 @@ void onMqttConnect(esp_mqtt_client_handle_t client)
     String subtopic = F(MQTT_TOPIC_CUSTOM "/#");
     mqttSubscribeTo(mqttGroupCommandTopic + subtopic);
     mqttSubscribeTo(mqttNodeCommandTopic + subtopic);
-#endif
-
-    /* Home Assistant auto-configuration */
-#ifdef HASP_USE_HA
-    if(mqttHAautodiscover) {
-        char topic[64];
-        snprintf_P(topic, sizeof(topic), PSTR("hass/status"));
-        mqttSubscribeTo(topic);
-        snprintf_P(topic, sizeof(topic), PSTR("homeassistant/status"));
-        mqttSubscribeTo(topic);
-    }
 #endif
 
     mqttSubscribeTo(mqttHassLwtTopic);

--- a/src/mqtt/hasp_mqtt_paho_async.cpp
+++ b/src/mqtt/hasp_mqtt_paho_async.cpp
@@ -176,17 +176,6 @@ static void mqtt_message_cb(char* topic, char* payload, size_t length)
         return;
 #endif
 
-#ifdef HASP_USE_HA
-    } else if(topic == strstr_P(topic, PSTR("homeassistant/status"))) { // HA discovery topic
-        if(mqttHAautodiscover && !strcasecmp_P((char*)payload, PSTR("online"))) {
-            dispatch_mtx.lock();
-            dispatch_current_state(TAG_MQTT);
-            dispatch_mtx.unlock();
-            mqtt_ha_register_auto_discovery();
-        }
-        return;
-#endif
-
     } else {
         // Other topic
         LOG_ERROR(TAG_MQTT, F(D_MQTT_INVALID_TOPIC));
@@ -338,12 +327,6 @@ static void onConnect(void* context, MQTTAsync_successData* response)
 
 #ifdef HASP_USE_BROADCAST
     topic = MQTT_PREFIX "/" MQTT_TOPIC_BROADCAST "/" MQTT_TOPIC_COMMAND "/#";
-    mqtt_subscribe(mqtt_client, topic.c_str());
-#endif
-
-    /* Home Assistant auto-configuration */
-#ifdef HASP_USE_HA
-    topic = "homeassistant/status";
     mqtt_subscribe(mqtt_client, topic.c_str());
 #endif
 

--- a/src/mqtt/hasp_mqtt_paho_single.cpp
+++ b/src/mqtt/hasp_mqtt_paho_single.cpp
@@ -129,15 +129,6 @@ static void mqtt_message_cb(char* topic, char* payload, size_t length)
         return;
 #endif
 
-#ifdef HASP_USE_HA
-    } else if(topic == strstr_P(topic, PSTR("homeassistant/status"))) { // HA discovery topic
-        if(mqttHAautodiscover && !strcasecmp_P((char*)payload, PSTR("online"))) {
-            dispatch_current_state(TAG_MQTT);
-            mqtt_ha_register_auto_discovery();
-        }
-        return;
-#endif
-
     } else {
         // Other topic
         LOG_ERROR(TAG_MQTT, F(D_MQTT_INVALID_TOPIC));
@@ -279,12 +270,6 @@ static void onConnect(void* context)
 
 #ifdef HASP_USE_BROADCAST
     topic = MQTT_PREFIX "/" MQTT_TOPIC_BROADCAST "/" MQTT_TOPIC_COMMAND "/#";
-    mqtt_subscribe(mqtt_client, topic.c_str());
-#endif
-
-    /* Home Assistant auto-configuration */
-#ifdef HASP_USE_HA
-    topic = "homeassistant/status";
     mqtt_subscribe(mqtt_client, topic.c_str());
 #endif
 

--- a/src/mqtt/hasp_mqtt_pubsubclient.cpp
+++ b/src/mqtt/hasp_mqtt_pubsubclient.cpp
@@ -167,15 +167,6 @@ static void mqtt_message_cb(char* topic, byte* payload, unsigned int length)
         return;
 #endif
 
-#ifdef HASP_USE_HA
-    } else if(topic == strstr_P(topic, PSTR("homeassistant/status"))) { // HA discovery topic
-        if(mqttHAautodiscover && !strcasecmp_P((char*)payload, PSTR("online"))) {
-            mqtt_ha_register_auto_discovery(); // auto-discovery first
-            dispatch_current_state(TAG_MQTT);  // send the data
-        }
-        return;
-#endif
-
     } else {
         // Other topic
         LOG_ERROR(TAG_MQTT, F(D_MQTT_INVALID_TOPIC));
@@ -321,17 +312,6 @@ void mqttStart()
 #ifdef HASP_USE_BROADCAST
     snprintf_P(topic, sizeof(topic), PSTR(MQTT_PREFIX "/" MQTT_TOPIC_BROADCAST "/" MQTT_TOPIC_COMMAND "/#"));
     mqttSubscribeTo(topic);
-#endif
-
-    /* Home Assistant auto-configuration */
-#ifdef HASP_USE_HA
-    if(mqttHAautodiscover) {
-        char topic[64];
-        snprintf_P(topic, sizeof(topic), PSTR("hass/status"));
-        mqttSubscribeTo(topic);
-        snprintf_P(topic, sizeof(topic), PSTR("homeassistant/status"));
-        mqttSubscribeTo(topic);
-    }
 #endif
 
     // Force any subscribed clients to toggle offline/online when we first connect to


### PR DESCRIPTION
The comment
https://github.com/HASwitchPlate/openHASP/issues/726#issuecomment-2116308777 states that the feature is not supported anymore. This change removes the reference from the user config and the related code to prevent confusion.