### PR TITLE
add lovyangfx custom offset for tft

### DIFF
--- a/src/drv/tft/tft_defines.h
+++ b/src/drv/tft/tft_defines.h
@@ -113,6 +113,12 @@
 #ifndef SPI_READ_FREQUENCY
 #define SPI_READ_FREQUENCY 0
 #endif
+#ifndef TFT_OFFSET_X
+#define TFT_OFFSET_X 0
+#endif
+#ifndef TFT_OFFSET_Y
+#define TFT_OFFSET_Y 0
+#endif
 #ifndef TFT_OFFSET_ROTATION
 #define TFT_OFFSET_ROTATION 0
 #endif

--- a/src/drv/tft/tft_driver_lovyangfx.cpp
+++ b/src/drv/tft/tft_driver_lovyangfx.cpp
@@ -204,8 +204,8 @@ static void configure_panel(lgfx::Panel_Device* panel, Preferences* prefs)
     cfg.memory_width  = prefs->getUInt("memory_width", cfg.panel_width);   // Maximum width supported by driver IC
     cfg.memory_height = prefs->getUInt("memory_height", cfg.panel_height); // Maximum height supported by driver IC
 
-    cfg.offset_x = prefs->getUInt("offset_x", 0); // Amount of offset in the X direction of the panel
-    cfg.offset_y = prefs->getUInt("offset_y", 0); // Amount of offset in the Y direction of the panel
+    cfg.offset_x = prefs->getUInt("offset_x", TFT_OFFSET_X); // Amount of offset in the X direction of the panel
+    cfg.offset_y = prefs->getUInt("offset_y", TFT_OFFSET_Y); // Amount of offset in the Y direction of the panel
     cfg.offset_rotation =
         prefs->getUInt("offset_rotation", TFT_OFFSET_ROTATION); // Offset of the rotation 0 ~ 7 (4 ~ 7 is upside down)
 

--- a/user_setups/esp32s3/waveshare s3 1_69 ctp.ini
+++ b/user_setups/esp32s3/waveshare s3 1_69 ctp.ini
@@ -1,0 +1,53 @@
+;**********************************************************;
+;   Waveshare ESP32-S3 TFT 1.69inch 240x280 C-Touch        ;
+;     - ST7789V2 TFT SPI 4-WIRE                            ;
+;     - CST816s touch controller                           ;
+;**********************************************************;
+
+[env:waveshare-s3-1_69-ctp]
+extends = arduino_esp32s3_v2, flash_16mb
+board = esp32-s3-devkitc-1
+board_build.arduino.memory_type = qio_opi
+
+build_flags =
+  -D HASP_MODEL="Waveshare micro TFT"
+  ${arduino_esp32s3_v2.build_flags}
+  ${esp32s3.ps_ram}
+;  -D USE_USB_CDC_CONSOLE=1
+;  -D ARDUINO_USB_MODE=1
+;  -D ARDUINO_USB_CDC_ON_BOOT=1
+
+  # --- Display settings ---
+  -D LGFX_USE_V1=1            ; for lovyangfx driver
+  -D HASP_USE_LGFX_TOUCH=1    ; for lovyangfx driver
+  -D ST7789_DRIVER=1
+  -D SPI_FREQUENCY=80000000
+  -D TFT_ROTATION=0 ; 0=0, 1=90, 2=180 or 3=270 degree
+  -D TFT_WIDTH=240
+  -D TFT_HEIGHT=280
+  -D TFT_OFFSET_Y=20
+  -D TFT_MOSI=7
+  -D TFT_SCLK=6
+  -D TFT_CS=5
+  -D TFT_DC=4
+  -D TFT_RST=8
+  -D TFT_BL=15
+  -D TFT_BCKL=15
+;  -D TFT_INVERSION_ON
+;  -D TFT_RGB_ORDER TFT_BGR
+  
+  # --- Touch settings ---
+    -D TOUCH_DRIVER=0x0816
+    -D TOUCH_SDA=11
+    -D TOUCH_SCL=10
+    -D TOUCH_RST=13
+    -D TOUCH_IRQ=14
+    -D TOUCH_CS=-1
+    -D I2C_TOUCH_FREQUENCY=400000
+    -D I2C_TOUCH_ADDRESS=0x15
+
+lib_deps =
+    ${arduino_esp32s3_v2.lib_deps}
+    ${lovyangfx.lib_deps}
+
+upload_protocol = esp-builtin


### PR DESCRIPTION
The TFT display that I use has an offset.

[https://www.waveshare.com/esp32-s3-touch-lcd-1.69.htm](https://www.waveshare.com/esp32-s3-touch-lcd-1.69.htm)

You can now set the offset in the environment :
```
[env:foobar]
build_flags =
  -D ST7789_DRIVER=1
  -D TFT_OFFSET_X=0
  -D TFT_OFFSET_Y=20
```