### PR TITLE
Sunton ESP32-8048S043C touch size adapted to screen size

### DIFF
--- a/user_setups/esp32s3/sunton-esp32-s3-tft.ini
+++ b/user_setups/esp32s3/sunton-esp32-s3-tft.ini
@@ -145,8 +145,8 @@ build_flags =
     -D TFT_PREFER_SPEED=13900000  ; 1/2 of Typical DCLK Frequency
     -D TFT_AUTO_FLUSH=1
     ; Touch Settings
-    -D TOUCH_WIDTH=480
-    -D TOUCH_HEIGHT=272
+    -D TOUCH_WIDTH=800
+    -D TOUCH_HEIGHT=480
     -D TOUCH_DRIVER=0x911
     -D TOUCH_SCL=20
     -D TOUCH_SDA=19


### PR DESCRIPTION
Corrected the size of the touch screen to match the screen size. Otherwise the touch is not really usable. I found the fix in this [Discussion on github](https://github.com/HASwitchPlate/openHASP/discussions/574). 

