### PR TITLE
Update T-Watch support (add PMIC support)

### DIFF
--- a/src/dev/esp32/esp32.cpp
+++ b/src/dev/esp32/esp32.cpp
@@ -451,6 +451,11 @@ long Esp32Device::get_uptime()
 #elif defined(M5STACK) || defined(M5STACKLGFX)
 #warning Building for M5Stack core2
 #include "dev/esp32/m5stackcore2.h"
+
+#elif defined(TWATCH)
+#warning Building for TTGo T-Watch
+#include "dev/esp32/twatch.h"
+
 #else
 dev::Esp32Device haspDevice;
 #endif

--- a/src/dev/esp32/esp32.h
+++ b/src/dev/esp32/esp32.h
@@ -86,6 +86,8 @@ class Esp32Device : public BaseDevice {
 #elif defined(M5STACK) || defined (M5STACKLGFX)
 // #warning Building for M5Stack core2
 #include "m5stackcore2.h"
+#elif defined(TWATCH)
+#include "twatch.h"
 #else
 using dev::Esp32Device;
 extern dev::Esp32Device haspDevice;

--- a/src/dev/esp32/twatch.cpp
+++ b/src/dev/esp32/twatch.cpp
@@ -1,0 +1,39 @@
+#include "twatch.h"
+
+#if defined(TWATCH)
+
+#include "Wire.h"
+#include "dev/esp32/esp32.h"
+
+/*
+ * This covers the TWatch 2019 and 2020 PMIC. Only the init function is implemented
+ * because the TWatch 2020 v1 variant has not just the backlight connected to LDO2, 
+ * but also the power for the display controller. This shouldn't get regulated down
+ * or be switched off (since the latter would require display being re-inited) so we
+ * don't let the user switch it off. 
+ * 
+ * This *could* get fixed, by detecting hardware type and changing behaviour, but
+ * this device isn't particularly common and OpenHASP probably isn't the proper tool
+ * for this hardware. It's nice to have some support though.
+*/
+namespace dev {
+    void TWatch::init(void) {
+        Wire.begin();
+        
+        Wire.beginTransmission(53);
+        Wire.write(0x12);
+        Wire.write(0b00000110); // Enable LDO2, DC-DC3, disable others
+        Wire.endTransmission();
+
+        // Section set LDO2 to 3.3V
+        uint8_t ldo_ctrl = ~0;
+        Wire.beginTransmission(53);
+        Wire.write(0x28);
+        Wire.write(ldo_ctrl);
+        Wire.endTransmission();
+    }
+}
+
+dev::TWatch haspDevice;
+
+#endif

--- a/src/dev/esp32/twatch.h
+++ b/src/dev/esp32/twatch.h
@@ -1,0 +1,20 @@
+#ifndef HASP_DEVICE_TWATCH
+#define HASP_DEVICE_TWATCH
+
+#if defined(TWATCH)
+
+#include "esp32.h"
+
+namespace dev {
+    class TWatch : public Esp32Device {
+      public:
+        void init() override;
+    };
+    
+}
+
+using dev::TWatch;
+extern dev::TWatch haspDevice;
+
+#endif
+#endif

--- a/user_setups/esp32/ttgo-t-watch.ini
+++ b/user_setups/esp32/ttgo-t-watch.ini
@@ -28,6 +28,7 @@ build_flags =
     -D TOUCH_RST=-1
     -D TOUCH_SDA=23
     -D TOUCH_SCL=32
+    -D TWATCH=1
 ;endregion
 
 lib_deps =
@@ -40,7 +41,7 @@ extends = ttgo-t-watch, flash_16mb
 
 build_flags =
     ${ttgo-t-watch.build_flags}
-    -D HASP_MODEL="TTgo T-Watch 2019"
+    -D HASP_MODEL="TTGo T-Watch 2019"
     -D INVERT_COLORS=1
 
 [env:ttgo-t-watch-2020]
@@ -48,7 +49,7 @@ extends = ttgo-t-watch, flash_16mb
 
 build_flags =
     ${ttgo-t-watch.build_flags}
-    -D HASP_MODEL="TTgo T-Watch 2020"
+    -D HASP_MODEL="TTGo T-Watch 2020"
     -D TFT_ROTATION=0
     ;-D TFT_ROTATION=2
     -D TOUCH_OFFSET_ROTATION=4 ; 1=swap xy, 2=invert x, 4=inverty


### PR DESCRIPTION
Support for the T-Watch PMIC was cut down significantly from what I originally planned - it now consists of turning on the power for the backlight on boot without anything further. 

The T-Watch 2020 V1 hardware variant also ties the Vcc of the display controller to the backlight power - dimming could make it act weirdly and switching off power would require re-initialising the display when switched back on.

The T-Watch devices are not first-class citizens for OpenHASP, but I don't think it matters - this isn't the software to be running on something battery powered anyway. This does at least update the existing configs and adds the PMIC support to make them at least usable.