### PR TITLE
Added exception for Lanbon L9 GPIO

### DIFF
--- a/src/dev/esp32/esp32.cpp
+++ b/src/dev/esp32/esp32.cpp
@@ -357,10 +357,15 @@ uint16_t Esp32Device::get_cpu_frequency()
 bool Esp32Device::is_system_pin(uint8_t pin)
 {
 // Also see esp32.cpp / hasp_gpio.cpp
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
+#if defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(LANBONL9)
     if((pin >= 22) && (pin <= 25)) return true; // unavailable
     if((pin >= 26) && (pin <= 32)) return true; // integrated SPI flash
     if((pin >= 33) && (pin <= 37)) return true; // octal flash or PSram
+#elif defined(CONFIG_IDF_TARGET_ESP32S3) && defined(LANBONL9)
+    if((pin >= 22) && (pin <= 25)) return true; // unavailable
+    if((pin >= 26) && (pin <= 32)) return true; // integrated SPI flash
+    if((pin >= 33) && (pin <= 34)) return true; // Pins 33 and 34 are not broken out on the WROOM module
+    // Lanbon L9 uses a WROOM module with Quad flash and pings 35 to 37 are available for use.
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)                          // Arduino NUM_DIGITAL_PINS = 48 (but espressif says it only has 46)
     // From https://hggh.github.io/esp32/2021/01/06/ESP32-S2-pinout.html, it looks like IO26 is for PSRAM
     // More info https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/_images/esp32-s2_saola1-pinout.jpg

--- a/user_setups/esp32s3/lanbon_l9.ini
+++ b/user_setups/esp32s3/lanbon_l9.ini
@@ -12,6 +12,7 @@ build_flags =
     ${esp32s3.build_flags}
     ${esp32s3.ps_ram}
     -D HASP_MODEL="Lanbon L9"
+    -D LANBONL9
     ;-D ARDUINO_USB_MODE=0
     ;-DARDUINO_USB_CDC_ON_BOOT
 	;-DUSE_USB_CDC_CONSOLE


### PR DESCRIPTION
* Added flag for Lanbon L9, to control available GPIO pins for L9 with ESP32-S3-N16R2 module with quad-PSRAM