### PR TITLE
Slower (reliable) upload speed for esp32-2432s022c

### DIFF
--- a/user_setups/esp32/esp32-2432s022c.ini
+++ b/user_setups/esp32/esp32-2432s022c.ini
@@ -1,7 +1,7 @@
 [env:esp32-2432s022c_4MB]
 extends = arduino_esp32_v2, flash_4mb
 board = esp32dev
-upload_speed = 921600
+upload_speed = 460800 ; (set it to 115200, if you're experiencing issue when uploading)
 
 build_flags =
     ${arduino_esp32_v2.build_flags}


### PR DESCRIPTION
The previous 921600 speed never worked for me (tested with 2 different USB-C cables)

Reverting to 460800 for reliability
