### PR TITLE
Add configuration for ESP32-S3 Pandatouch from BTT

### DIFF
--- a/user_setups/esp32s3/esp32-s3-pandatouch.ini
+++ b/user_setups/esp32s3/esp32-s3-pandatouch.ini
@@ -1,0 +1,84 @@
+;***************************************************;
+; BTT - Pandatouch                                  ;
+;           - Custom esp32-s3 board                 ;
+;           - 800 x 600 TFT                         ;
+;           - gt911 touch controller                ;
+;***************************************************;
+
+[esp32-s3-pandatouch]
+extends = arduino_esp32s3_v2
+board = esp32-s3-devkitc-1
+board_build.arduino.memory_type = qio_opi
+
+build_flags =
+    -D HASP_MODEL="ESP32-S3 Pandatouch"
+    ${arduino_esp32s3_v2.build_flags}
+    ${esp32s3.ps_ram}
+
+;region -- ArduinoGFX build options ------------------------
+    -D HASP_USE_ARDUINOGFX=1
+    -D ST7701_DRIVER=1
+    -D TFT_WIDTH=800
+    -D TFT_HEIGHT=480
+    ; Bus Settings
+    -D TFT_CS=-1
+    -D TFT_SCLK=-1
+    -D TFT_MOSI=-1
+    -D TFT_DE=38
+    -D TFT_VSYNC=-1
+    -D TFT_HSYNC=-1
+    -D TFT_PCLK=5
+    -D TFT_R0=6
+    -D TFT_R1=7
+    -D TFT_R2=8
+    -D TFT_R3=9
+    -D TFT_R4=10
+    -D TFT_G0=11
+    -D TFT_G1=12
+    -D TFT_G2=13
+    -D TFT_G3=14
+    -D TFT_G4=15
+    -D TFT_G5=16
+    -D TFT_B0=17
+    -D TFT_B1=18
+    -D TFT_B2=48
+    -D TFT_B3=47
+    -D TFT_B4=39
+    -D TFT_DC=-1
+    -D TFT_MISO=-1
+    -D TFT_RST=46
+    -D TFT_BUSY=-1
+    -D TFT_BCKL=21
+    -D BACKLIGHT_FREQUENCY=30000
+    ; Panel Settings
+    -D TFT_HSYNC_POLARITY=0
+    -D TFT_HSYNC_FRONT_PORCH=16
+    -D TFT_HSYNC_PULSE_WIDTH=4
+    -D TFT_HSYNC_BACK_PORCH=32
+    -D TFT_VSYNC_POLARITY=0
+    -D TFT_VSYNC_FRONT_PORCH=16
+    -D TFT_VSYNC_PULSE_WIDTH=4
+    -D TFT_VSYNC_BACK_PORCH=32
+    -D TFT_PCLK_ACTIVE_NEG=1
+    -D TFT_PREFER_SPEED=14800000
+    -D TFT_AUTO_FLUSH=1
+    ; Touch Settings
+    -D TOUCH_DRIVER=0x911
+    -D TOUCH_WIDTH=800
+    -D TOUCH_HEIGHT=480
+    -D TOUCH_SDA=2
+    -D TOUCH_SCL=1
+    -D TOUCH_RST=41
+    ;-D TOUCH_IRQ=40 ; if you provide the correct IRQ pin the device will crash
+    -D TOUCH_IRQ=-1
+    -D I2C_TOUCH_FREQUENCY=400000
+    -D I2C_TOUCH_ADDRESS=0x14
+;endregion
+
+lib_deps =
+    ${arduino_esp32s3_v2.lib_deps}
+    ${arduinogfx.lib_deps}
+    ${goodix.lib_deps}
+
+[env:esp32-s3-pandatouch_8MB]
+extends = esp32-s3-pandatouch, flash_8mb


### PR DESCRIPTION
since the BTT Pandatouch will be obsolete in the near future, because of breaking changes in the firmware of the Bambulab Printers, the device is kind of useless.

Bittreetech released a example project with the pinout (https://github.com/bigtreetech/PandaTouch_PlatformIO)

i created a configuration for openHASP and seems like it's working :)