### PR TITLE
Changed post TFT reset delay to work for BTT Panda Touch

### DIFF
--- a/src/drv/tft/tft_driver_arduinogfx.cpp
+++ b/src/drv/tft/tft_driver_arduinogfx.cpp
@@ -134,7 +134,7 @@ void ArduinoGfx::init(int w, int h)
         digitalWrite(TFT_RST, LOW);
         delay(120);
         digitalWrite(TFT_RST, HIGH);
-        delay(120);
+        delay(300);
     }
 
     Arduino_RGBPanel_Mod* bus = new Arduino_RGBPanel_Mod(


### PR DESCRIPTION
BTT Panda Touch would not always initialise the TFT screen, changing the post reset delay from 120 to 300 resolves this issue.