### PR TITLE
Fix linux_sdl build: add missing limits.h include for PATH_MAX

### DIFF
--- a/src/hasp_gui.cpp
+++ b/src/hasp_gui.cpp
@@ -27,6 +27,10 @@ File pFileOut;
 bool gui_pop_screenshot_request(void);
 #endif
 
+#if defined(POSIX)
+#include <limits.h>
+#endif
+
 #if ESP32
 static SemaphoreHandle_t xGuiSemaphore = NULL;
 static TaskHandle_t g_lvgl_task_handle;


### PR DESCRIPTION
## Summary

- The POSIX screenshot code added in #997 uses `PATH_MAX` and `realpath()`, which require `<limits.h>` on Linux
- On macOS these symbols are implicitly available through system headers, so `darwin_sdl` built fine but `linux_sdl` failed with `'PATH_MAX' was not declared in this scope`
- Adds a conditional `#include <limits.h>` for POSIX builds in `src/hasp_gui.cpp`

**This fix enables the screenshot feature on the Linux desktop build** — all code paths (MQTT command, F12 shortcut, file I/O) use standard POSIX APIs that work identically on both macOS and Linux. The missing include was the only blocker.

## Build failure

CI run: https://github.com/HASwitchPlate/openHASP/actions/runs/22374148869/job/64760315273

```
src/hasp_gui.cpp:768:27: error: 'PATH_MAX' was not declared in this scope
  768 |             char fullpath[PATH_MAX];
src/hasp_gui.cpp:769:36: error: 'fullpath' was not declared in this scope
  769 |             if(realpath(pFileName, fullpath)) {
```

## Test plan

- [x] `pio run -e linux_sdl` in Docker (Debian Bookworm + libsdl2-dev) — builds successfully with the fix

## Related

- Original code PR: #997
- Docs update PR: https://github.com/HASwitchPlate/openHASP-docs/pull/51