### PR TITLE
Add ESP32-2432S024 board support improvements

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -109,7 +109,7 @@ lib_deps =
 
 [lovyangfx]
 lib_deps =
-    lovyan03/LovyanGFX@^1.1.12
+    lovyan03/LovyanGFX@~1.2.21
 
 [arduinogfx]
 lib_deps =

--- a/platformio_override-template.ini
+++ b/platformio_override-template.ini
@@ -86,6 +86,8 @@ extra_default_envs =
         ; sensecap-indicator-d1_8MB
     ; -- Sunton -----------------------------------
         ; esp32-2432s022c_4MB
+        ; esp32-2432s024c_4MB
+        ; esp32-2432s024r_4MB
         ; esp32-2432s028r_4MB
         ; esp32-2432s028r-ili9342_4MB
         ; esp32-2432s028r_v2_4MB

--- a/src/drv/tft/tft_driver_lovyangfx.cpp
+++ b/src/drv/tft/tft_driver_lovyangfx.cpp
@@ -446,7 +446,14 @@ lgfx::ITouch* _init_touch(Preferences* preferences)
         LOG_DEBUG(TAG_TFT, F("%s - %d"), __FILE__, __LINE__);
 
         cfg.bus_shared      = true;
-        cfg.offset_rotation = 0;
+        cfg.offset_rotation = TOUCH_OFFSET_ROTATION;
+#ifdef SPI_TOUCH_FREQUENCY
+        cfg.freq            = SPI_TOUCH_FREQUENCY;
+#endif
+        cfg.x_min = 0;    // XPT2046 raw ADC minimum (12-bit)
+        cfg.x_max = 4095; // XPT2046 raw ADC maximum (12-bit)
+        cfg.y_min = 0;
+        cfg.y_max = 4095;
 
         cfg.spi_host = SPI3_HOST;
         // cfg.pin_sclk = 18;

--- a/src/sys/gpio/hasp_gpio.cpp
+++ b/src/sys/gpio/hasp_gpio.cpp
@@ -45,6 +45,10 @@ hasp_gpio_config_t gpioConfig[HASP_NUM_GPIO_CONFIG] = {
     {.pin = RELAY_3, .group = 3, .gpio_function = OUTPUT, .type = LIGHT_RELAY},
     {.pin = LED_GREEN, .group = 5, .gpio_function = OUTPUT, .type = LED_G},
     {.pin = LED_BLUE, .group = 6, .gpio_function = OUTPUT, .type = LED_B}
+#elif defined(ESP32_2432S024)
+    {.pin = LED_RED, .group = 4, .gpio_function = OUTPUT, .type = LED_R, .inverted = 1},
+    {.pin = LED_GREEN, .group = 5, .gpio_function = OUTPUT, .type = LED_G, .inverted = 1},
+    {.pin = LED_BLUE, .group = 6, .gpio_function = OUTPUT, .type = LED_B, .inverted = 1}
 #endif
     //    {2, 8, INPUT, LOW}, {3, 9, OUTPUT, LOW}, {4, 10, INPUT, HIGH}, {5, 11, OUTPUT, LOW}, {6, 12, INPUT, LOW},
 };

--- a/user_setups/esp32/esp32-2432s024.ini
+++ b/user_setups/esp32/esp32-2432s024.ini
@@ -14,13 +14,37 @@ build_flags =
     ${esp32.no_ps_ram}
     -D ESP32_2432S024=1
 
+;region -- RGB LED (MHP5050RGBDT, common-anode, active LOW) --------
+; The LED anodes share a common 3.3V rail via current-limiting resistors.
+; GPIOs sink current (active LOW = LED ON), so firmware must use inverted=1.
+; See hasp_gpio.cpp for the compile-time defaults that set this up.
+;
+; PCB resistor values (NOTE: published schematics are incorrect for this board):
+;   LED_RED  (GPIO4)  : 1kΩ  -- measured Vf = 1.79V
+;   LED_GREEN (GPIO17): 100Ω -- measured Vf = 2.29V
+;   LED_BLUE (GPIO16) : 100Ω -- measured Vf = 1.90V
+;
+; For balanced white (BT.601 luminance weights R=29.9% G=58.7% B=11.4%),
+; replace resistors as follows (calculated from measured Vf, V(λ) eye sensitivity,
+; targeting ~12mA max per GPIO):
+;   LED_RED  : replace 1kΩ → 150Ω  (~9.4mA)
+;   LED_GREEN: replace 100Ω → 150Ω (~6.1mA)
+;   LED_BLUE : keep 100Ω            (~13mA, limited by low Vf)
+; Without this hardware fix, white appears turquoise due to red being ~7x too dim.
+; Software compensation could be possible but is not implemented in the current
+; firmware release.
+    -D LED_RED=4
+    -D LED_GREEN=17
+    -D LED_BLUE=16
+;endregion
+
 ;region -- TFT_eSPI build options ------------------------
     ${esp32.hspi}        ; Use HSPI hardware SPI bus
     ;-D USER_SETUP_LOADED=1
     -D LGFX_USE_V1=1
     -D ILI9341_DRIVER=1
     -D HASP_USE_LGFX_TOUCH=1
-    -D TFT_ROTATION=0  ; 0=0, 1=90, 2=180 or 3=270 degree, Mirrors: 6, 5, 4, 3
+    -D TFT_ROTATION=2  ; 0=0, 1=90, 2=180 or 3=270 degree, Mirrors: 6, 5, 4, 3
     -D TFT_WIDTH=240
     -D TFT_HEIGHT=320
     -D TFT_CS=15      ;// Chip select control pin
@@ -53,6 +77,7 @@ build_flags =
     -D TOUCH_MOSI=13
     -D TOUCH_MISO=12
     -D TOUCH_IRQ=36
+    -D TOUCH_OFFSET_ROTATION=2  ; touch rotation to match TFT_ROTATION=2
     -D SPI_TOUCH_FREQUENCY=2500000
 
 lib_deps =


### PR DESCRIPTION
Getting back to getting this board sorted a little more. The github action builds were actually broken when I uploaded it, so iterated a little more on this (with some help from Claude)

- Fix XPT2046 touch coordinates for rotated displays: use TOUCH_OFFSET_ROTATION instead of hardcoded 0, add ifdef-guarded SPI_TOUCH_FREQUENCY, and set full 12-bit ADC range (0-4095)
- Add compile-time GPIO defaults for ESP32-2432S024 RGB LED (MHP5050RGBDT on GPIO4/17/16) with inverted=1 for active-LOW common-anode wiring
- Set TFT_ROTATION=2 and TOUCH_OFFSET_ROTATION=2 for correct portrait orientation on the 2432S024 display
- Correct LED pin assignments (GREEN=17, BLUE=16) and add detailed comments documenting PCB resistor values, measured Vf, and hardware white-balance fix (schematic is incorrect for this board)
- Add esp32-2432s024r and esp32-2432s024c to template env list
- Bump LovyanGFX to ~1.2.21 to fix compilation issue