### PR TITLE
Add standalone XPT2046 touch driver for RGB/ArduinoGFX boards (Sunton 4827S043R)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
           - out: seeed-studios
             env: "sensecap-indicator-d1_8MB"
           - out: sunton
-            env: "esp32-2432s022c_4MB -e esp32-2432s028r_4MB -e esp32-2432s028r-ili9342_4MB -e esp32-2432s028r_v2_4MB -e esp32-2432s028r-st7789_4MB -e esp32-2432s032c_4MB -e esp32-3248s035c_4MB -e esp32-3248s035r_4MB -e sunton-4827s043c_16MB -e sunton-8048s043c_16MB -e sunton-8048s050c_16MB -e sunton-8048s070c_16MB -e cyd-2424s012_4MB -e esp32-2432s024c_4MB -e esp32-2432s024r_4MB"
+            env: "esp32-2432s022c_4MB -e esp32-2432s028r_4MB -e esp32-2432s028r-ili9342_4MB -e esp32-2432s028r_v2_4MB -e esp32-2432s028r-st7789_4MB -e esp32-2432s032c_4MB -e esp32-3248s035c_4MB -e esp32-3248s035r_4MB -e sunton-4827s043c_16MB -e sunton-4827s043r_16MB -e sunton-8048s043c_16MB -e sunton-8048s050c_16MB -e sunton-8048s070c_16MB -e cyd-2424s012_4MB -e esp32-2432s024c_4MB -e esp32-2432s024r_4MB"
           - out: waveshare
             env: "esp32-one_ili9486 -e esp32-one_st7796 -e ws_esp32_s3_touch_lcd_4p3 -e ws_esp32_s3_touch_lcd_4 -e waveshare-esp32-s3-touch-lcd-7"
           - out: wireless-tag

--- a/platformio_override-template.ini
+++ b/platformio_override-template.ini
@@ -95,6 +95,7 @@ extra_default_envs =
         ; esp32-3248s035c_4MB
         ; esp32-3248s035r_4MB
         ; sunton-4827s043c_16MB
+        ; sunton-4827s043r_16MB
         ; sunton-8048s043c_16MB
         ; sunton-8048s050c_16MB
         ; sunton-8048s070c_16MB

--- a/src/drv/touch/touch_driver.h
+++ b/src/drv/touch/touch_driver.h
@@ -57,6 +57,9 @@ class BaseTouch {
 #elif TOUCH_DRIVER == 0x2046 && defined(LGFX_USE_V1) && defined(HASP_USE_LGFX_TOUCH)
 #warning Building for LovyanGFX XPT2046
 #include "touch_driver_lovyangfx.h"
+#elif TOUCH_DRIVER == 0x2046
+#warning Building for standalone XPT2046
+#include "touch_driver_xpt2046.h"
 #elif TOUCH_DRIVER == 0x0911 && defined(LGFX_USE_V1) && defined(HASP_USE_LGFX_TOUCH)
 #warning Building for LovyanGFX GT911
 #include "touch_driver_lovyangfx.h"

--- a/src/drv/touch/touch_driver_xpt2046.cpp
+++ b/src/drv/touch/touch_driver_xpt2046.cpp
@@ -1,0 +1,192 @@
+/* MIT License - Copyright (c) 2019-2024 Francis Van Roie
+   For full license information read the LICENSE file in the project folder */
+
+/* Standalone XPT2046 resistive touch on its own SPI bus, for RGB-parallel
+   boards driven by ArduinoGFX (which has no built-in touch companion). */
+
+#if defined(ARDUINO) && (TOUCH_DRIVER == 0x2046) && !defined(USER_SETUP_LOADED) && !defined(LGFX_USE_V1)
+#include <Arduino.h>
+#include <SPI.h>
+#include "ArduinoLog.h"
+#include "hasp_conf.h"
+
+#include "touch_driver_xpt2046.h"
+#include "touch_driver.h" // base class
+
+#include "../../hasp/hasp.h" // for hasp_sleep_state
+extern uint8_t hasp_sleep_state;
+
+// ---- Pins (from the board's user_setup .ini) --------------------------------
+#ifndef TOUCH_SCLK
+#define TOUCH_SCLK 12
+#endif
+#ifndef TOUCH_MISO
+#define TOUCH_MISO 13
+#endif
+#ifndef TOUCH_MOSI
+#define TOUCH_MOSI 11
+#endif
+#ifndef TOUCH_CS
+#define TOUCH_CS 38
+#endif
+#ifndef TOUCH_IRQ
+#define TOUCH_IRQ 18
+#endif
+
+// ---- Calibration (12-bit raw ADC range -> pixels). Defaults proven on the
+//      Sunton 4827S043R via ESPHome. Override per-board with build flags. ------
+#ifndef TOUCH_XPT2046_XMIN
+#define TOUCH_XPT2046_XMIN 280
+#endif
+#ifndef TOUCH_XPT2046_XMAX
+#define TOUCH_XPT2046_XMAX 3860
+#endif
+#ifndef TOUCH_XPT2046_YMIN
+#define TOUCH_XPT2046_YMIN 340
+#endif
+#ifndef TOUCH_XPT2046_YMAX
+#define TOUCH_XPT2046_YMAX 3860
+#endif
+// Orientation tweaks (default: none -> matches ESPHome swap_xy/mirror = false)
+#ifndef TOUCH_XPT2046_SWAP_XY
+#define TOUCH_XPT2046_SWAP_XY 0
+#endif
+#ifndef TOUCH_XPT2046_MIRROR_X
+#define TOUCH_XPT2046_MIRROR_X 0
+#endif
+#ifndef TOUCH_XPT2046_MIRROR_Y
+#define TOUCH_XPT2046_MIRROR_Y 0
+#endif
+
+// XPT2046 control bytes (differential mode, 12-bit). Axis assignment matches
+// ESPHome's xpt2046 component: X measured with 0x90, Y with 0xD0.
+#define XPT2046_CMD_X 0x90
+#define XPT2046_CMD_Y 0xD0
+#define XPT2046_SAMPLES 5
+
+#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32S2)
+static SPIClass touchSpi(FSPI);
+#else
+static SPIClass touchSpi(VSPI);
+#endif
+static const SPISettings touchSpiSettings(2000000, MSBFIRST, SPI_MODE0);
+
+// Read one 12-bit conversion for the given control byte.
+static uint16_t xpt2046_read_raw(uint8_t cmd)
+{
+    touchSpi.transfer(cmd);
+    uint8_t hi   = touchSpi.transfer(0x00);
+    uint8_t lo   = touchSpi.transfer(0x00);
+    uint16_t val = ((uint16_t)hi << 8 | lo) >> 3; // 12-bit result
+    return val & 0x0FFF;
+}
+
+// Median-of-samples for one axis to reject the noisy first/last conversions.
+static uint16_t xpt2046_sample(uint8_t cmd)
+{
+    uint16_t buf[XPT2046_SAMPLES];
+    for(uint8_t i = 0; i < XPT2046_SAMPLES; i++) buf[i] = xpt2046_read_raw(cmd);
+    // simple insertion sort (tiny N) then take the middle sample
+    for(uint8_t i = 1; i < XPT2046_SAMPLES; i++) {
+        uint16_t k = buf[i];
+        int8_t j   = i - 1;
+        while(j >= 0 && buf[j] > k) {
+            buf[j + 1] = buf[j];
+            j--;
+        }
+        buf[j + 1] = k;
+    }
+    return buf[XPT2046_SAMPLES / 2];
+}
+
+namespace dev {
+
+void TouchXpt2046::init(int w, int h)
+{
+    _width  = w;
+    _height = h;
+
+    pinMode(TOUCH_IRQ, INPUT);
+    pinMode(TOUCH_CS, OUTPUT);
+    digitalWrite(TOUCH_CS, HIGH);
+
+    // Dedicated SPI bus; ss = -1 so we drive CS manually across the X+Y burst.
+    touchSpi.begin(TOUCH_SCLK, TOUCH_MISO, TOUCH_MOSI, -1);
+
+    LOG_INFO(TAG_DRVR, "XPT2046 %s (sclk=%d miso=%d mosi=%d cs=%d irq=%d)", D_SERVICE_STARTED, TOUCH_SCLK,
+             TOUCH_MISO, TOUCH_MOSI, TOUCH_CS, TOUCH_IRQ);
+}
+
+void TouchXpt2046::set_rotation(uint8_t rotation)
+{
+    _rotation = rotation;
+}
+
+bool TouchXpt2046::is_driver_pin(uint8_t pin)
+{
+    return pin == TOUCH_SCLK || pin == TOUCH_MISO || pin == TOUCH_MOSI || pin == TOUCH_CS || pin == TOUCH_IRQ;
+}
+
+IRAM_ATTR bool TouchXpt2046::read(lv_indev_drv_t* indev_driver, lv_indev_data_t* data)
+{
+    // PENIRQ is LOW while the panel is pressed.
+    if(digitalRead(TOUCH_IRQ) != LOW) {
+        data->state = LV_INDEV_STATE_REL;
+        return false;
+    }
+
+    touchSpi.beginTransaction(touchSpiSettings);
+    digitalWrite(TOUCH_CS, LOW);
+    uint16_t rawX = xpt2046_sample(XPT2046_CMD_X);
+    uint16_t rawY = xpt2046_sample(XPT2046_CMD_Y);
+    // Re-check IRQ: a release during the burst yields garbage.
+    bool still_down = (digitalRead(TOUCH_IRQ) == LOW);
+    digitalWrite(TOUCH_CS, HIGH);
+    touchSpi.endTransaction();
+
+    if(!still_down) {
+        data->state = LV_INDEV_STATE_REL;
+        return false;
+    }
+
+    // Select which raw ADC axis feeds each screen axis. On RGB/ArduinoGFX boards
+    // the panel is often oriented so screen-X is driven by the touch Y wire.
+    // XMIN/XMAX always calibrate whatever ADC axis feeds screen-X (same for Y).
+#if TOUCH_XPT2046_SWAP_XY
+    uint16_t adcX = rawY;
+    uint16_t adcY = rawX;
+#else
+    uint16_t adcX = rawX;
+    uint16_t adcY = rawY;
+#endif
+    if(adcX < TOUCH_XPT2046_XMIN) adcX = TOUCH_XPT2046_XMIN;
+    if(adcX > TOUCH_XPT2046_XMAX) adcX = TOUCH_XPT2046_XMAX;
+    if(adcY < TOUCH_XPT2046_YMIN) adcY = TOUCH_XPT2046_YMIN;
+    if(adcY > TOUCH_XPT2046_YMAX) adcY = TOUCH_XPT2046_YMAX;
+
+    int32_t x = map(adcX, TOUCH_XPT2046_XMIN, TOUCH_XPT2046_XMAX, 0, _width - 1);
+    int32_t y = map(adcY, TOUCH_XPT2046_YMIN, TOUCH_XPT2046_YMAX, 0, _height - 1);
+
+#if TOUCH_XPT2046_MIRROR_X
+    x = _width - 1 - x;
+#endif
+#if TOUCH_XPT2046_MIRROR_Y
+    y = _height - 1 - y;
+#endif
+
+    data->point.x = (lv_coord_t)x;
+    data->point.y = (lv_coord_t)y;
+    data->state   = LV_INDEV_STATE_PR;
+
+    if(hasp_sleep_state != HASP_SLEEP_OFF) hasp_update_sleep_state(); // wake on touch
+    hasp_set_sleep_offset(0);
+
+    LOG_VERBOSE(TAG_DRVR, "XPT2046 raw=%u,%u -> %d,%d", rawX, rawY, (int)x, (int)y);
+    return false;
+}
+
+} // namespace dev
+
+dev::TouchXpt2046 haspTouch;
+
+#endif // ARDUINO && TOUCH_DRIVER == 0x2046 && !TFT_eSPI && !LovyanGFX

--- a/src/drv/touch/touch_driver_xpt2046.h
+++ b/src/drv/touch/touch_driver_xpt2046.h
@@ -1,0 +1,46 @@
+/* MIT License - Copyright (c) 2019-2024 Francis Van Roie
+   For full license information read the LICENSE file in the project folder */
+
+/* Standalone XPT2046 resistive-touch driver.
+ *
+ * openHASP's other XPT2046 support is welded to the TFT_eSPI / LovyanGFX
+ * display drivers (they own the SPI touch read). RGB-parallel boards must use
+ * ArduinoGFX for the display, which has no touch companion -- so those boards
+ * fell through to the dead "Generic Touch" stub. This driver runs XPT2046 on
+ * its OWN SPI bus so resistive touch works alongside an ArduinoGFX RGB panel
+ * (e.g. Sunton ESP32-4827S043R). */
+
+#ifndef HASP_XPT2046_TOUCH_DRIVER_H
+#define HASP_XPT2046_TOUCH_DRIVER_H
+
+#ifdef ARDUINO
+#include "lvgl.h"
+#include "touch_driver.h" // base class
+
+namespace dev {
+
+class TouchXpt2046 : public BaseTouch {
+  public:
+    IRAM_ATTR bool read(lv_indev_drv_t* indev_driver, lv_indev_data_t* data);
+    void init(int w, int h);
+    void set_rotation(uint8_t rotation);
+    const char* get_touch_model()
+    {
+        return "XPT2046";
+    }
+    bool is_driver_pin(uint8_t pin);
+
+  private:
+    uint8_t _rotation = 0;
+    int _width        = 0;
+    int _height       = 0;
+};
+
+} // namespace dev
+
+using dev::TouchXpt2046;
+extern dev::TouchXpt2046 haspTouch;
+
+#endif // ARDUINO
+
+#endif // HASP_XPT2046_TOUCH_DRIVER_H

--- a/user_setups/esp32s3/sunton-esp32-s3-tft.ini
+++ b/user_setups/esp32s3/sunton-esp32-s3-tft.ini
@@ -55,8 +55,14 @@ build_flags =
     -D TFT_B3=9
     -D TFT_B4=1
 
-[sunton-4827s043r_16MB]
+[env:sunton-4827s043r_16MB]
 extends = sunton-esp32-s3-tft, flash_16mb
+
+; Exclude the dead legacy touch shim: src/drv/old/hasp_drv_touch.cpp is unused
+; (its only caller in hasp_gui.cpp is commented out) but still compiled, and its
+; TOUCH_DRIVER==0x2046 branch assumes a TFT_eSPI display object -- which breaks on
+; this ArduinoGFX/RGB board. The modern haspTouch path (touch_driver_xpt2046) is used instead.
+build_src_filter = ${env.build_src_filter} -<drv/old/hasp_drv_touch.cpp>
 
 build_flags =
     -D HASP_MODEL="Sunton ESP32-4827S043R"
@@ -77,13 +83,21 @@ build_flags =
     -D TFT_PCLK_ACTIVE_NEG=1
     -D TFT_PREFER_SPEED=9000000   ; Typical DCLK Frequency
     -D TFT_AUTO_FLUSH=1
-    ; Touch Settings
-    ;-D TOUCH_DRIVER=0x2046
+    ; Touch Settings -- standalone XPT2046 driver (own SPI bus) for the RGB/ArduinoGFX path
+    -D TOUCH_DRIVER=0x2046
     -D TOUCH_SCLK=12
     -D TOUCH_MISO=13
     -D TOUCH_MOSI=11
     -D TOUCH_CS=38
     -D TOUCH_IRQ=18
+    ; XPT2046 calibration (measured on-panel 2026-07-06). This board's touch is
+    ; rotated vs the display, so screen-X is fed by the touch Y-wire -> SWAP_XY.
+    ; XMIN/XMAX = raw window feeding screen-X; YMIN/YMAX = raw window feeding screen-Y.
+    -D TOUCH_XPT2046_SWAP_XY=1
+    -D TOUCH_XPT2046_XMIN=300
+    -D TOUCH_XPT2046_XMAX=3700
+    -D TOUCH_XPT2046_YMIN=380
+    -D TOUCH_XPT2046_YMAX=3660
 
 
 [env:sunton-4827s043c_16MB]


### PR DESCRIPTION
## Problem

openHASP's XPT2046 support is only wired into the **TFT_eSPI** and **LovyanGFX** display drivers, which own the SPI touch read. RGB-parallel boards must use **ArduinoGFX** for the display, so on those boards `TOUCH_DRIVER=0x2046` matches no branch in `touch_driver.h` and falls through to the no-op *Generic Touch* stub — resistive touch is silently dead. This is the blocker behind the unresolved reports of no touch on the Sunton **ESP32-4827S043R** (e.g. discussion #648).

## Change

A self-contained XPT2046 touch driver that runs on its **own SPI bus**, independent of the display driver:

- **`src/drv/touch/touch_driver_xpt2046.{h,cpp}`** — `TouchXpt2046 : BaseTouch` using a dedicated `SPIClass`, PENIRQ press-detection, median-filtered 12-bit reads, and build-flag calibration (`TOUCH_XPT2046_XMIN/XMAX/YMIN/YMAX`, `SWAP_XY`, `MIRROR_X/Y`). Guarded to compile **only** when `TOUCH_DRIVER==0x2046` and neither TFT_eSPI (`USER_SETUP_LOADED`) nor LovyanGFX (`LGFX_USE_V1`) is active — so it is a no-op on every existing board.
- **`src/drv/touch/touch_driver.h`** — dispatch to the new driver in a branch placed *after* the existing TFT_eSPI/LovyanGFX `0x2046` branches, so those still win when their display driver is active.
- **`user_setups/esp32s3/sunton-esp32-s3-tft.ini`** — turn the existing `[sunton-4827s043r_16MB]` template into a buildable `[env:...]`, enable `TOUCH_DRIVER=0x2046` with the board's touch pins, and add a measured calibration. The dead, uncalled `src/drv/old/hasp_drv_touch.cpp` is excluded for this env via `build_src_filter` (its `0x2046` branch assumes a TFT_eSPI display object and won't compile on ArduinoGFX).

## Testing

Built and flashed to a Sunton **ESP32-4827S043R**. Display renders and **resistive touch works**, calibrated across the full 480×272 panel (corner taps map correctly). No other board's build is affected — both the new driver and the legacy-file exclusion are scoped (compile guards / per-env `build_src_filter`).

## Notes

- The touch pins for the 4827S043R (SCLK 12 / MISO 13 / MOSI 11 / CS 38 / IRQ 18) were already present in the board template; this makes them usable.
- Calibration defaults are board-specific build flags and can be overridden per board.
