### PR TITLE
Add support for LilyGo T4-S3 board with RM690B0 display and CST226 touch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
           - out: lanbon
             env: lanbon_l8 -e lanbon_l9_v1_0 -e lanbon_l9_v3_3
           - out: lilygo-ttgo
-            env: "lilygo-lily-pi_st7796 -e lilygo-lily-pi_ili9481 -e ttgo-t7-v1_5_ili9341_4MB -e ttgo-t7-v1_5_ili9341_16MB"
+            env: "lilygo-lily-pi_st7796 -e lilygo-lily-pi_ili9481 -e ttgo-t7-v1_5_ili9341_4MB -e ttgo-t7-v1_5_ili9341_16MB -e lilygo-t4-s3_16MB"
           - out: lolin
             env: lolin-d32-pro_ili9341
           - out: m5stack

--- a/platformio_override-template.ini
+++ b/platformio_override-template.ini
@@ -66,6 +66,7 @@ extra_default_envs =
         ; ttgo-esp32_tdisplay_v1
         ; ttgo-t-display-s3_st7789_16MB
         ; ttgo-t-display-s3_st7789_touch_16MB
+        ; lilygo-t4-s3_16MB
     ; -- Lolin ------------------------------------
         ; lolin-d32-pro_ili9341
     ; -- M5stack ----------------------------------

--- a/src/drv/tft/tft_driver.h
+++ b/src/drv/tft/tft_driver.h
@@ -33,6 +33,7 @@ enum lv_hasp_obj_type_t {
     TFT_PANEL_RGB,
     TFT_PANEL_EPD,
     TFT_PANEL_GC9A01,
+    TFT_PANEL_RM690B0,
     TFT_PANEL_LAST,
 };
 

--- a/src/drv/tft/tft_driver_lovyangfx.cpp
+++ b/src/drv/tft/tft_driver_lovyangfx.cpp
@@ -336,6 +336,13 @@ lgfx::Panel_Device* LovyanGfx::_init_panel(lgfx::IBus* bus)
             LOG_VERBOSE(TAG_TFT, F("Panel_GC9A01"));
             break;
         }
+        case TFT_PANEL_RM690B0: {
+#if defined(LGFX_USE_QSPI)
+            panel = new lgfx::Panel_RM690B0();
+            LOG_VERBOSE(TAG_TFT, F("Panel_RM690B0"));
+#endif
+            break;
+        }
         default: { // Needs to be in curly braces
             LOG_FATAL(TAG_TFT, F(D_SERVICE_START_FAILED ": %s line %d"), __FILE__, __LINE__);
         }
@@ -510,6 +517,31 @@ lgfx::ITouch* _init_touch(Preferences* preferences)
         cfg.offset_rotation = TOUCH_OFFSET_ROTATION;
 
         // I2C接続の場合
+        cfg.i2c_port = I2C_TOUCH_PORT;
+        cfg.i2c_addr = I2C_TOUCH_ADDRESS;
+        cfg.pin_sda  = TOUCH_SDA;
+        cfg.pin_scl  = TOUCH_SCL;
+        cfg.freq     = I2C_TOUCH_FREQUENCY;
+
+        touch->config(cfg);
+        return touch;
+    }
+#endif
+
+#if TOUCH_DRIVER == 0x0226 || TOUCH_DRIVER == 0x226
+    {
+        auto touch = new lgfx::Touch_CST226();
+        auto cfg   = touch->config();
+
+        cfg.x_min           = 0;
+        cfg.x_max           = TFT_WIDTH - 1;
+        cfg.y_min           = 0;
+        cfg.y_max           = TFT_HEIGHT - 1;
+        cfg.pin_int         = TOUCH_IRQ;
+        cfg.pin_rst         = TOUCH_RST;
+        cfg.bus_shared      = false;
+        cfg.offset_rotation = TOUCH_OFFSET_ROTATION;
+
         cfg.i2c_port = I2C_TOUCH_PORT;
         cfg.i2c_addr = I2C_TOUCH_ADDRESS;
         cfg.pin_sda  = TOUCH_SDA;
@@ -1126,6 +1158,67 @@ void LovyanGfx::init(int w, int h)
         _touch_instance->config(cfg);
         _panel_instance->setTouch(_touch_instance);
     }
+#elif defined(LILYGO_T4_S3)
+    pinMode(PWR_EN, OUTPUT);
+    digitalWrite(PWR_EN, HIGH);
+
+    auto _panel_instance = new lgfx::Panel_RM690B0();
+    auto _bus_instance   = new lgfx::Bus_SPI();
+    auto _touch_instance = new lgfx::Touch_CST226();
+
+    {
+        auto cfg       = _bus_instance->config();
+        cfg.freq_write = SPI_FREQUENCY;
+        cfg.freq_read  = SPI_READ_FREQUENCY;
+        cfg.pin_sclk   = TFT_SCK;
+        cfg.pin_io0    = TFT_D0;
+        cfg.pin_io1    = TFT_D1;
+        cfg.pin_io2    = TFT_D2;
+        cfg.pin_io3    = TFT_D3;
+        cfg.spi_host   = SPI2_HOST;
+        cfg.spi_mode   = SPI_MODE0;
+        cfg.dma_channel = SPI_DMA_CH_AUTO;
+        _bus_instance->config(cfg);
+        _panel_instance->setBus(_bus_instance);
+    }
+
+    {
+        auto cfg             = _panel_instance->config();
+        cfg.pin_cs           = TFT_CS;
+        cfg.pin_rst          = TFT_RST;
+        cfg.pin_busy         = TFT_BUSY;
+        cfg.memory_width     = 452;
+        cfg.memory_height    = 600;
+        cfg.panel_width      = TFT_WIDTH;
+        cfg.panel_height     = TFT_HEIGHT;
+        cfg.offset_x         = TFT_OFFSET_X;
+        cfg.offset_y         = TFT_OFFSET_Y;
+        cfg.offset_rotation  = TFT_ROTATION;
+        cfg.readable         = true;
+        cfg.invert           = false;
+        cfg.rgb_order        = false;
+        cfg.bus_shared       = false;
+        _panel_instance->config(cfg);
+    }
+
+    {
+        auto cfg            = _touch_instance->config();
+        cfg.x_min           = 0;
+        cfg.x_max           = TFT_WIDTH - 1;
+        cfg.y_min           = 0;
+        cfg.y_max           = TFT_HEIGHT - 1;
+        cfg.pin_int         = TOUCH_IRQ;
+        cfg.pin_rst         = TOUCH_RST;
+        cfg.bus_shared      = false;
+        cfg.offset_rotation = TOUCH_OFFSET_ROTATION;
+        cfg.i2c_port        = I2C_TOUCH_PORT;
+        cfg.i2c_addr        = I2C_TOUCH_ADDRESS;
+        cfg.pin_sda         = TOUCH_SDA;
+        cfg.pin_scl         = TOUCH_SCL;
+        cfg.freq            = I2C_TOUCH_FREQUENCY;
+        _touch_instance->config(cfg);
+        _panel_instance->setTouch(_touch_instance);
+    }
 #else
 
     Preferences preferences;
@@ -1396,6 +1489,8 @@ const char* LovyanGfx::get_tft_model()
     return "RM68140";
 #elif defined(GC9A01_DRIVER)
     return "GC9A01";
+#elif defined(RM690B0_DRIVER)
+    return "RM690B0";
 #else
     return "Other";
 #endif
@@ -1439,6 +1534,8 @@ uint32_t LovyanGfx::get_tft_driver()
     return TFT_PANEL_RGB;
 #elif defined(GC9A01_DRIVER)
     return TFT_PANEL_GC9A01;
+#elif defined(RM690B0_DRIVER)
+    return TFT_PANEL_RM690B0;
 #else
     return TFT_PANEL_UNKNOWN;
 #endif

--- a/src/hasp_gui.cpp
+++ b/src/hasp_gui.cpp
@@ -114,6 +114,19 @@ IRAM_ATTR void gui_flush_cb(lv_disp_drv_t* disp, const lv_area_t* area, lv_color
     screenshotIsDirty = true;
 }
 
+#if defined(RM690B0_DRIVER) || defined(LILYGO_T4_S3)
+void gui_rounder_cb(lv_disp_drv_t* disp_drv, lv_area_t* area)
+{
+    area->x1 = area->x1 & ~1; // Round down start X to even
+    area->x2 = area->x2 | 1;  // Round up end X to odd (width = x2 - x1 + 1 = even)
+    area->y1 = area->y1 & ~1; // Round down start Y to even
+    area->y2 = area->y2 | 1;  // Round up end Y to odd (height = y2 - y1 + 1 = even)
+
+    if(area->x2 >= disp_drv->hor_res) area->x2 = disp_drv->hor_res - 1;
+    if(area->y2 >= disp_drv->ver_res) area->y2 = disp_drv->ver_res - 1;
+}
+#endif
+
 void gui_antiburn_cb(lv_disp_drv_t* disp, const lv_area_t* area, lv_color_t* color_p)
 {
     /*  uint32_t w   = (area->x2 - area->x1 + 1);
@@ -242,6 +255,9 @@ void guiSetup()
     lv_disp_drv_init(&disp_drv);
     disp_drv.buffer   = &disp_buf;
     disp_drv.flush_cb = gui_flush_cb;
+#if defined(RM690B0_DRIVER) || defined(LILYGO_T4_S3)
+    disp_drv.rounder_cb = gui_rounder_cb;
+#endif
 
     if(gui_settings.rotation % 2) {
         disp_drv.hor_res = tft_height;
@@ -287,6 +303,9 @@ void guiSetup()
     lv_disp_drv_init(&disp_drv);
     disp_drv.buffer    = &disp_buf;
     disp_drv.flush_cb  = gui_flush_cb;
+#if defined(RM690B0_DRIVER) || defined(LILYGO_T4_S3)
+    disp_drv.rounder_cb = gui_rounder_cb;
+#endif
     disp_drv.hor_res   = tft_width;
     disp_drv.ver_res   = tft_height;
 

--- a/user_setups/esp32s3/lilygo-t4-s3.ini
+++ b/user_setups/esp32s3/lilygo-t4-s3.ini
@@ -1,0 +1,65 @@
+;***************************************************;
+;        LilyGo T4-S3 2.41" AMOLED Touch            ;
+;             - ESP32-S3-DevKitC-1 / BOARD_AMOLED_241 ;
+;             - RM690B0 AMOLED Display (450x600 QSPI) ;
+;             - CST226 Capacitive Touch Controller  ;
+;***************************************************;
+
+[lilygo-t4-s3]
+extends = arduino_esp32s3_v2
+board = esp32-s3-devkitc-1
+board_build.arduino.memory_type = qio_opi
+
+build_flags =
+    -D HASP_MODEL="LilyGo T4-S3"
+    -D LILYGO_T4_S3=1
+    ${arduino_esp32s3_v2.build_flags}
+    ${esp32s3.ps_ram}
+    -D ARDUINO_USB_MODE=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+
+;region -- LovyanGFX display & touch options -------------
+    -D LGFX_USE_V1=1
+    -D LGFX_USE_QSPI=1
+    -D RM690B0_DRIVER=1
+    -D TFT_WIDTH=450
+    -D TFT_HEIGHT=600
+    -D TFT_OFFSET_X=16
+    -D TFT_ROTATION=0
+    -D SPI_FREQUENCY=80000000
+
+    ; QSPI Display Bus Pins
+    -D TFT_CS=11
+    -D TFT_SCK=15
+    -D TFT_D0=14
+    -D TFT_D1=10
+    -D TFT_D2=16
+    -D TFT_D3=12
+    -D TFT_RST=13
+    -D TFT_BCKL=9
+    -D PWR_EN=9
+
+    ; Touch Settings
+    -D TOUCH_DRIVER=0x0226
+    -D HASP_USE_LGFX_TOUCH=1
+    -D TOUCH_SDA=6
+    -D TOUCH_SCL=7
+    -D TOUCH_IRQ=8
+    -D TOUCH_RST=17
+    -D I2C_TOUCH_FREQUENCY=100000
+    -D I2C_TOUCH_ADDRESS=0x5A
+
+    ; SD Card Pins
+    -D SD_MISO=4
+    -D SD_MOSI=2
+    -D SD_SCLK=3
+    -D SD_CS=1
+;endregion
+
+lib_deps =
+    ${arduino_esp32s3_v2.lib_deps}
+    ${lovyangfx.lib_deps}
+
+
+[env:lilygo-t4-s3_16MB]
+extends = lilygo-t4-s3, flash_16mb


### PR DESCRIPTION
## Description

Add support for LilyGo T4-S3 board with 2.4" RM690B0 450x600 AMOLED display and CST226 touchscreen

## Related Issues

[Related discussion re LoyvanGFX support of AMOLED panels](https://github.com/lovyan03/LovyanGFX/issues/547)

## Type of Change

- [X] New device / board support
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / core change
- [ ] Documentation
- [ ] Other

## Scope

**This PR is focused on:**  
Only adding support for the LilyGo T4-S3 2.4" AMOLED device

**It does NOT include:**  
Mirrored rotated modes do not work correctly due to being unhandled in upstream LoyvanGFX despite hardware support. A separate PR adding support for these modes in Panel_AMOLED.cpp will be posted.

## Checklist

- [X] My changes only affect **one clear goal**
- [X] I have tested the changes on real hardware (if applicable)
- [X] The code builds cleanly for at least one existing board
- [X] I have added/updated documentation where needed
- [X] No unrelated files were changed
