### PR TITLE
Add ESP32-S3 ILI9486 ADC shield support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
           - env: d1-mini-esp32_ili9341
             out: d1-mini-esp32
           - out: d1-r32-espduino32
-            env: "d1-r32-waveshare_ili9486 -e d1-r32-unoshield_ili9341_adc -e d1-r32-unoshield_ili9486_adc"
+            env: "d1-r32-waveshare_ili9486 -e d1-r32-unoshield_ili9341_adc -e d1-r32-unoshield_ili9486_adc -e esp32s3-devkitc-ili9486-unoshield-adc"
           - out: dustinwatts
             env: "freetouchdeck_4MB -e freetouchdeck_8MB -e esp32-touchdown"
           - out: elecrow

--- a/src/drv/tft/tft_driver_lovyangfx.cpp
+++ b/src/drv/tft/tft_driver_lovyangfx.cpp
@@ -1385,6 +1385,41 @@ void LovyanGfx::set_invert(bool invert)
     tft.invertDisplay(invert);
 }
 
+void LovyanGfx::restore_analog_touch_pins()
+{
+#if defined(CONFIG_IDF_TARGET_ESP32S3) && (TOUCH_DRIVER == 0x0ADC)
+    auto panel = tft.getPanel();
+    if(!panel || !panel->getBus() || panel->getBus()->busType() != lgfx::v1::bus_parallel8) return;
+
+    auto cfg = ((lgfx::Bus_Parallel8*)panel->getBus())->config();
+    const int8_t touch_pins[] = {TFT_D6, TFT_DC, TFT_WR, TFT_D7};
+
+    for(int8_t pin : touch_pins) {
+        if(pin == cfg.pin_rs) {
+            gpio_matrix_out(pin, LCD_DC_IDX, false, false);
+        } else if(pin == cfg.pin_wr) {
+            gpio_matrix_out(pin, LCD_PCLK_IDX, false, false);
+        } else if(pin == cfg.pin_d0) {
+            gpio_matrix_out(pin, LCD_DATA_OUT0_IDX, false, false);
+        } else if(pin == cfg.pin_d1) {
+            gpio_matrix_out(pin, LCD_DATA_OUT0_IDX + 1, false, false);
+        } else if(pin == cfg.pin_d2) {
+            gpio_matrix_out(pin, LCD_DATA_OUT0_IDX + 2, false, false);
+        } else if(pin == cfg.pin_d3) {
+            gpio_matrix_out(pin, LCD_DATA_OUT0_IDX + 3, false, false);
+        } else if(pin == cfg.pin_d4) {
+            gpio_matrix_out(pin, LCD_DATA_OUT0_IDX + 4, false, false);
+        } else if(pin == cfg.pin_d5) {
+            gpio_matrix_out(pin, LCD_DATA_OUT0_IDX + 5, false, false);
+        } else if(pin == cfg.pin_d6) {
+            gpio_matrix_out(pin, LCD_DATA_OUT0_IDX + 6, false, false);
+        } else if(pin == cfg.pin_d7) {
+            gpio_matrix_out(pin, LCD_DATA_OUT0_IDX + 7, false, false);
+        }
+    }
+#endif
+}
+
 /* Update TFT */
 void IRAM_ATTR LovyanGfx::flush_pixels(lv_disp_drv_t* disp, const lv_area_t* area, lv_color_t* color_p)
 {
@@ -1392,10 +1427,15 @@ void IRAM_ATTR LovyanGfx::flush_pixels(lv_disp_drv_t* disp, const lv_area_t* are
     uint32_t h   = (area->y2 - area->y1 + 1);
     uint32_t len = w * h;
 
-    tft.startWrite();                                        /* Start new TFT transaction */
+    tft.startWrite(); /* Start new TFT transaction */
+#if defined(ILI9486_DRIVER)
+    tft.setWindow(area->x1, area->y1, area->x2, area->y2);
+    tft.writePixels((const uint16_t*)&color_p->full, len, true);
+#else
     tft.setAddrWindow(area->x1, area->y1, w, h);             /* set the working window */
     tft.writePixels((lgfx::rgb565_t*)&color_p->full, w * h); /* Write words at once */
-    tft.endWrite();                                          /* terminate TFT transaction */
+#endif
+    tft.endWrite(); /* terminate TFT transaction */
 
     /* Tell lvgl that flushing is done */
     lv_disp_flush_ready(disp);

--- a/src/drv/tft/tft_driver_lovyangfx.h
+++ b/src/drv/tft/tft_driver_lovyangfx.h
@@ -39,6 +39,7 @@ class LovyanGfx : BaseTft {
 
     void set_rotation(uint8_t rotation);
     void set_invert(bool invert);
+    void restore_analog_touch_pins();
 
     void flush_pixels(lv_disp_drv_t* disp, const lv_area_t* area, lv_color_t* color_p);
     bool is_driver_pin(uint8_t pin);

--- a/src/drv/touch/touch_driver_analog.h
+++ b/src/drv/touch/touch_driver_analog.h
@@ -13,6 +13,9 @@
 #include "touch_driver.h" // base class
 
 #include "../../hasp/hasp.h" // for hasp_sleep_state
+#if defined(LGFX_USE_V1) && defined(CONFIG_IDF_TARGET_ESP32S3)
+#include "../tft/tft_driver.h"
+#endif
 extern uint8_t hasp_sleep_state;
 #define MINPRESSURE 200
 #define MAXPRESSURE 2400
@@ -38,10 +41,17 @@ class AnalogTouch : public BaseTouch {
     {
         static TSPoint tp;
         tp = ts.getPoint();
+#if defined(LGFX_USE_V1) && defined(CONFIG_IDF_TARGET_ESP32S3)
+        haspTft.restore_analog_touch_pins();
+#endif
         if(tp.z < MINPRESSURE) {
             data->state = LV_INDEV_STATE_REL;
         } else {
+#ifdef TOUCH_INVERT_X
+            data->point.x = map(tp.x, TS_LEFT, TS_RT, max_x, 0);
+#else
             data->point.x = map(tp.x, TS_LEFT, TS_RT, 0, max_x);
+#endif
             data->point.y = map(tp.y, TS_BOT, TS_TOP, max_y, 0);
             data->state   = LV_INDEV_STATE_PR;
             hasp_set_sleep_offset(0); // Reset the offset

--- a/user_setups/esp32s3/esp32s3-devkitc-ili9486-unoshield-adc.ini
+++ b/user_setups/esp32s3/esp32s3-devkitc-ili9486-unoshield-adc.ini
@@ -1,0 +1,49 @@
+;***************************************************;
+; ESP32-S3 DevKitC with a 3.5 inch ILI9486 Arduino  ;
+; UNO shield using 8-bit parallel LCD and ADC touch ;
+;***************************************************;
+
+[esp32s3-devkitc-ili9486-unoshield-adc]
+extends = arduino_esp32s3_v2, flash_16mb
+board = esp32-s3-devkitc-1
+board_build.arduino.memory_type = qio_opi
+
+build_flags =
+    -D HASP_MODEL="ESP32-S3 ILI9486 UNO Shield"
+    ${arduino_esp32s3_v2.build_flags}
+    ${esp32s3.ps_ram}
+
+    ; LovyanGFX ILI9486 display over an 8-bit i80 bus.
+    -D LGFX_USE_V1=1
+    -D ILI9486_DRIVER=1
+    -D TFT_WIDTH=320
+    -D TFT_HEIGHT=480
+    -D TFT_ROTATION=0
+    -D TFT_BCKL=18
+    -D TFT_CS=10
+    -D TFT_DC=9
+    -D TFT_RST=11
+    -D TFT_WR=17
+    -D TFT_RD=8
+    -D TFT_D0=2
+    -D TFT_D1=3
+    -D TFT_D2=4
+    -D TFT_D3=5
+    -D TFT_D4=6
+    -D TFT_D5=7
+    -D TFT_D6=15
+    -D TFT_D7=16
+    -D SPI_FREQUENCY=20000000
+
+    ; Direct resistive touch uses D6/DC/WR/D7 on this shield.
+    -D TOUCH_DRIVER=0x0ADC
+    -D TOUCH_anDC=9
+    -D TOUCH_anWR=17
+    -D TOUCH_INVERT_X=1
+
+lib_deps =
+    ${arduino_esp32s3_v2.lib_deps}
+    ${lovyangfx.lib_deps}
+
+[env:esp32s3-devkitc-ili9486-unoshield-adc]
+extends = esp32s3-devkitc-ili9486-unoshield-adc


### PR DESCRIPTION
## Summary

Adds support for an ESP32-S3 DevKitC wired to a 3.5 inch ILI9486 UNO-format resistive-touch shield.

- adds the `esp32s3-devkitc-ili9486-unoshield-adc` build environment
- restores ESP32-S3 parallel-LCD GPIO-matrix output after a direct analog touch read reconfigures shared LCD pins
- uses the working LovyanGFX ILI9486 parallel flush path for this panel
- adds a board-local X-axis touch inversion option and CI build coverage

## Hardware

Tested with:

- ESP32-S3 DevKitC, 16 MiB flash and 8 MiB PSRAM
- 320x480 ILI9486 3.5 inch UNO-format 8-bit parallel TFT shield
- direct four-wire resistive touch sharing D6, D/C, WR, and D7

The environment selects LovyanGFX, keeps the project default FreeType support enabled, and sets the tested 20 MHz parallel write clock.

## Problem

`TouchScreen::getPoint()` temporarily changes the touch electrodes to GPIO/ADC mode. On ESP32-S3 parallel displays, that removes the LCD peripheral matrix routes when an electrode is also an LCD signal. Subsequent LVGL flushes then do not reach the panel correctly.

After each analog touch read, this change inspects the active LovyanGFX `Bus_Parallel8` configuration and restores only the overlapping D/C, WR, and data-line routes. Separate-pin touch configurations and non-parallel buses are unchanged.

## Validation

- `pio run -e esp32s3-devkitc-ili9486-unoshield-adc`
- `pio run -e d1-r32-unoshield_ili9486_adc`
- physical validation of dashboard rendering, FreeType fonts, touch orientation, repeated press/release events, display updates after touch, Wi-Fi, MQTT, and reboot

## Note

The full-screen 300 KiB PSRAM LVGL draw buffer used by the validation device is intentionally not enabled by this environment. It is an optional redraw-smoothness tuning for boards with sufficient PSRAM, not a requirement for display or touch support.
